### PR TITLE
Implement separate user projection to be used for validation

### DIFF
--- a/service/settings.gradle.kts
+++ b/service/settings.gradle.kts
@@ -9,6 +9,7 @@ include(":langsapp")
 include(":user-commands")
 include(":user-follow-commands")
 include(":user-profile-query")
+include(":user-query")
 
 dependencyResolutionManagement {
     repositories {

--- a/service/user-commands/build.gradle.kts
+++ b/service/user-commands/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":components:auth"))
     api(project(":components:events"))
     api(project(":components:messagebus"))
+    api(project(":user-query"))
     api(libs.kotlin.stdlib.jdk8)
     api(libs.kotlin.reflect)
     api(libs.kotlinx.coroutines.core)

--- a/service/user-commands/src/main/kotlin/com/klimek/langsapp/service/user/commands/UserCommandsController.kt
+++ b/service/user-commands/src/main/kotlin/com/klimek/langsapp/service/user/commands/UserCommandsController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class UserCommandsController(
     private val tokenAuthenticator: TokenAuthenticator,
-    private val userCommandsService: UserCommandsService
+    private val userCommandsService: UserCommandsService,
 ) : UserApi {
 
     override suspend fun createUser(

--- a/service/user-commands/src/main/kotlin/com/klimek/langsapp/service/user/commands/storage/UserCommandsRepository.kt
+++ b/service/user-commands/src/main/kotlin/com/klimek/langsapp/service/user/commands/storage/UserCommandsRepository.kt
@@ -10,20 +10,6 @@ import org.springframework.stereotype.Repository
 class UserCommandsRepository {
     private val storage = UserCommandsInMemoryStorage
 
-    fun containsUserWithName(currentUserId: String, userName: String): Either<StorageError, Boolean> =
-        storage
-            .userNamesToIds[userName]
-            .let {
-                it != null && it != currentUserId
-            }
-            .right()
-
-    fun containsUserWithId(currentUserId: String): Either<StorageError, Boolean> =
-        storage
-            .userIdsToNames
-            .containsKey(currentUserId)
-            .right()
-
     fun storeUserCreatedEvent(userCreatedEvent: UserCreatedEvent): Either<StorageError, Unit> =
         storage
             .storeUserCreatedEvent(userCreatedEvent)

--- a/service/user-follow-commands/build.gradle.kts
+++ b/service/user-follow-commands/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":components:auth"))
     api(project(":components:events"))
     api(project(":components:messagebus"))
+    api(project(":user-query"))
     api(libs.kotlin.stdlib.jdk8)
     api(libs.kotlin.reflect)
     api(libs.kotlinx.coroutines.core)

--- a/service/user-follow-commands/src/main/kotlin/com/klimek/langsapp/service/user/follow/commands/UserFollowCommandsController.kt
+++ b/service/user-follow-commands/src/main/kotlin/com/klimek/langsapp/service/user/follow/commands/UserFollowCommandsController.kt
@@ -33,7 +33,12 @@ class UserFollowCommandsController(
                     followerUserId = authenticatedUser.userId,
                     userId = followRequest.userId
                 ).fold(
-                    ifLeft = { ResponseEntity.internalServerError().build() },
+                    ifLeft = {
+                        if (it is UserFollowCommandsService.Companion.Error.UserNotFound)
+                            ResponseEntity.notFound().build()
+                        else
+                            ResponseEntity.internalServerError().build()
+                    },
                     ifRight = { hasAddedFollow ->
                         if (hasAddedFollow) ResponseEntity.status(HttpStatus.CREATED).body(Unit)
                         else ResponseEntity.status(HttpStatus.NO_CONTENT).body(Unit)
@@ -60,7 +65,12 @@ class UserFollowCommandsController(
                     followerUserId = authenticatedUser.userId,
                     userId = followRequest.userId
                 ).fold(
-                    ifLeft = { ResponseEntity.internalServerError().build() },
+                    ifLeft = {
+                        if (it is UserFollowCommandsService.Companion.Error.UserNotFound)
+                            ResponseEntity.notFound().build()
+                        else
+                            ResponseEntity.internalServerError().build()
+                    },
                     ifRight = { hasRemovedFollow ->
                         if (hasRemovedFollow) ResponseEntity.status(HttpStatus.CREATED).body(Unit)
                         else ResponseEntity.status(HttpStatus.NO_CONTENT).body(Unit)

--- a/service/user-follow-commands/src/main/kotlin/com/klimek/langsapp/service/user/follow/commands/UserFollowCommandsService.kt
+++ b/service/user-follow-commands/src/main/kotlin/com/klimek/langsapp/service/user/follow/commands/UserFollowCommandsService.kt
@@ -2,58 +2,83 @@ package com.klimek.langsapp.service.user.follow.commands
 
 import arrow.core.Either
 import arrow.core.flatMap
+import arrow.core.left
 import arrow.core.right
 import com.klimek.langsapp.events.follow.UserFollowEvent
 import com.klimek.langsapp.events.generateEventsProperties
 import com.klimek.langsapp.service.user.follow.commands.event.UserFollowEventsPublisher
 import com.klimek.langsapp.service.user.follow.commands.storage.UserFollowCommandsRepository
+import com.klimek.langsapp.service.user.query.UserId
+import com.klimek.langsapp.service.user.query.UserQueryService
 import org.springframework.stereotype.Service
 
 @Service
 class UserFollowCommandsService(
     private val userFollowEventsPublisher: UserFollowEventsPublisher,
-    private val userFollowCommandsRepository: UserFollowCommandsRepository
+    private val userFollowCommandsRepository: UserFollowCommandsRepository,
+    private val userQueryService: UserQueryService
 ) {
 
-    fun followUser(followerUserId: String, userId: String): Either<ServiceError, Boolean> =
-        userFollowCommandsRepository.getLastStoredEvent(followerUserId, userId)
-            .mapLeft { ServiceError() }
+    fun followUser(followerUserId: String, userId: String): Either<Error, Boolean> =
+        validateUserExists(userId = userId)
             .flatMap {
-                if (it?.isFollowed == true) false.right()
-                else insertAndSendUserFollowEvent(
-                    UserFollowEvent(
-                        eventProperties = generateEventsProperties(),
-                        followerUserId = followerUserId,
-                        userId = userId,
-                        isFollowed = true
-                    )
-                )
-                    .map { true }
-            }
-
-    fun unfollowUser(followerUserId: String, userId: String): Either<ServiceError, Boolean> =
-        userFollowCommandsRepository.getLastStoredEvent(followerUserId, userId)
-            .mapLeft { ServiceError() }
-            .flatMap {
-                if (it?.isFollowed == false) false.right()
-                else
-                    insertAndSendUserFollowEvent(
-                        UserFollowEvent(
-                            eventProperties = generateEventsProperties(),
-                            followerUserId = followerUserId,
-                            userId = userId,
-                            isFollowed = false
+                userFollowCommandsRepository
+                    .getLastStoredEvent(followerUserId, userId)
+                    .mapLeft { Error.ServiceError }
+                    .flatMap {
+                        if (it?.isFollowed == true) false.right()
+                        else insertAndSendUserFollowEvent(
+                            UserFollowEvent(
+                                eventProperties = generateEventsProperties(),
+                                followerUserId = followerUserId,
+                                userId = userId,
+                                isFollowed = true
+                            )
                         )
-                    )
-                        .map { true }
+                            .map { true }
+                    }
             }
 
-    fun insertAndSendUserFollowEvent(userFollowEvent: UserFollowEvent): Either<ServiceError, Unit> =
+    fun unfollowUser(followerUserId: String, userId: String): Either<Error, Boolean> =
+        validateUserExists(userId)
+            .flatMap {
+                userFollowCommandsRepository.getLastStoredEvent(followerUserId, userId)
+                    .mapLeft { Error.ServiceError }
+                    .flatMap {
+                        if (it?.isFollowed == false) false.right()
+                        else
+                            insertAndSendUserFollowEvent(
+                                UserFollowEvent(
+                                    eventProperties = generateEventsProperties(),
+                                    followerUserId = followerUserId,
+                                    userId = userId,
+                                    isFollowed = false
+                                )
+                            )
+                                .map { true }
+                    }
+            }
+
+    fun insertAndSendUserFollowEvent(userFollowEvent: UserFollowEvent): Either<Error, Unit> =
         userFollowCommandsRepository.storeUserFollowEvent(userFollowEvent)
-            .mapLeft { ServiceError() }
+            .mapLeft { Error.ServiceError }
             .onRight { userFollowEventsPublisher.sendUserFollowEvent(userFollowEvent) }
 
+    private fun validateUserExists(userId: String): Either<Error, Unit> =
+        userQueryService
+            .getUserById(userId = UserId(userId))
+            .fold(
+                ifLeft = { Error.ServiceError.left() },
+                ifRight = { user ->
+                    if (user == null) Error.UserNotFound.left()
+                    else Unit.right()
+                }
+            )
+
     companion object {
-        class ServiceError
+        sealed class Error {
+            object ServiceError : Error()
+            object UserNotFound : Error()
+        }
     }
 }

--- a/service/user-query/build.gradle.kts
+++ b/service/user-query/build.gradle.kts
@@ -1,0 +1,34 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+
+    id("org.graalvm.buildtools.native")
+}
+
+version = findProperty("scm.commit.hash") ?: error("Missing current commit hash")
+group = findProperty("package.group") ?: error("Missing package group")
+
+
+dependencies {
+    api(project(":components:events"))
+    api(project(":components:messagebus"))
+    api(libs.kotlin.stdlib.jdk8)
+    api(libs.kotlin.reflect)
+    api(libs.arrow.core)
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = libs.versions.jvm.target.get()
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/Models.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/Models.kt
@@ -1,0 +1,9 @@
+package com.klimek.langsapp.service.user.query
+
+@JvmInline
+value class UserId(val value: String)
+
+@JvmInline
+value class UserName(val value: String)
+
+data class User(val userId: UserId, val userName: UserName)

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/UserQueryConfiguration.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/UserQueryConfiguration.kt
@@ -1,0 +1,17 @@
+package com.klimek.langsapp.service.user.query
+
+import com.klimek.langsapp.service.messagebus.MessageBus
+import com.klimek.langsapp.service.user.query.event.MessageBusEventsListener
+import com.klimek.langsapp.service.user.query.storage.UserQueryRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class UserQueryConfiguration {
+
+    @Bean
+    fun eventsPublisher(
+        messageBus: MessageBus,
+        repository: UserQueryRepository
+    ) = MessageBusEventsListener(messageBus = messageBus, repository = repository)
+}

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/UserQueryService.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/UserQueryService.kt
@@ -1,0 +1,41 @@
+package com.klimek.langsapp.service.user.query
+
+import arrow.core.Either
+import com.klimek.langsapp.service.user.query.storage.UserQueryRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserQueryService(
+    private val repository: UserQueryRepository
+) {
+
+    fun getUserById(userId: UserId): Either<ServiceError, User?> =
+        repository
+            .getNameById(userId)
+            .mapLeft { ServiceError() }
+            .map { userName ->
+                userName?.let {
+                    User(
+                        userId = userId,
+                        userName = it
+                    )
+                }
+            }
+
+    fun getUserByName(userName: UserName): Either<ServiceError, User?> =
+        repository
+            .getUserIdByName(userName)
+            .mapLeft { ServiceError() }
+            .map { userId ->
+                userId?.let {
+                    User(
+                        userId = it,
+                        userName = userName
+                    )
+                }
+            }
+
+    companion object {
+        class ServiceError
+    }
+}

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/event/EventsListener.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/event/EventsListener.kt
@@ -1,0 +1,27 @@
+package com.klimek.langsapp.service.user.query.event
+
+import com.klimek.langsapp.events.user.UserCreatedEvent
+import com.klimek.langsapp.events.user.UserUpdatedEvent
+import com.klimek.langsapp.service.user.query.UserId
+import com.klimek.langsapp.service.user.query.UserName
+import com.klimek.langsapp.service.user.query.storage.UserQueryRepository
+
+abstract class EventsListener(
+    private val repository: UserQueryRepository
+) {
+    fun onUserCreatedEvent(event: UserCreatedEvent) {
+        repository
+            .storeUser(
+                UserId(event.userId),
+                UserName(event.userName)
+            )
+    }
+
+    fun onUserUpdatedEvent(event: UserUpdatedEvent) {
+        repository
+            .storeUser(
+                UserId(event.userId),
+                UserName(event.userName)
+            )
+    }
+}

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/event/MessageBusEventsListener.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/event/MessageBusEventsListener.kt
@@ -1,0 +1,23 @@
+package com.klimek.langsapp.service.user.query.event
+
+import com.klimek.langsapp.events.user.UserCreatedEvent
+import com.klimek.langsapp.events.user.UserUpdatedEvent
+import com.klimek.langsapp.service.messagebus.MessageBus
+import com.klimek.langsapp.service.user.query.storage.UserQueryRepository
+
+class MessageBusEventsListener(
+    messageBus: MessageBus,
+    repository: UserQueryRepository
+) : EventsListener(repository) {
+    init {
+        println("Registering listener $this to event bus: $messageBus")
+        messageBus.register(UserCreatedEvent::class.java) {
+            println("$this Received event: $it")
+            if (it is UserCreatedEvent) onUserCreatedEvent(it)
+        }
+        messageBus.register(UserUpdatedEvent::class.java) {
+            println("$this Received event: $it")
+            if (it is UserUpdatedEvent) onUserUpdatedEvent(it)
+        }
+    }
+}

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/storage/UserQueryInMemoryStorage.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/storage/UserQueryInMemoryStorage.kt
@@ -1,0 +1,6 @@
+package com.klimek.langsapp.service.user.query.storage
+
+
+object UserQueryInMemoryStorage {
+    val users = mutableMapOf<String, String>()
+}

--- a/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/storage/UserQueryRepository.kt
+++ b/service/user-query/src/main/kotlin/com/klimek/langsapp/service/user/query/storage/UserQueryRepository.kt
@@ -1,0 +1,34 @@
+package com.klimek.langsapp.service.user.query.storage
+
+import arrow.core.Either
+import arrow.core.right
+import com.klimek.langsapp.service.user.query.UserId
+import com.klimek.langsapp.service.user.query.UserName
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserQueryRepository {
+
+    fun getUserIdByName(userName: UserName): Either<StorageError, UserId?> =
+        UserQueryInMemoryStorage
+            .users
+            .entries
+            .find { it.value == userName.value }
+            ?.let { UserId(it.key) }
+            .right()
+
+    fun getNameById(userId: UserId): Either<StorageError, UserName?> =
+        UserQueryInMemoryStorage
+            .users[userId.value]
+            ?.let { UserName(it) }
+            .right()
+
+    fun storeUser(userId: UserId, userName: UserName): Either<StorageError, Unit> {
+        UserQueryInMemoryStorage.users[userId.value] = userName.value
+        return Unit.right()
+    }
+
+    companion object {
+        class StorageError
+    }
+}


### PR DESCRIPTION
In order to make possible to validate if user commands can be executed
it is useful to implement a separate user projection (that could be shared between modules).

This way, instead of providing validation in each of modules, it can be implemented in single place
and reused in others.

The PR implements new `user-query` module that observes `user created` and `user updated` events
and builds projection of current user object. 

Then the projection is used in `user-commands` module for validating the commands such as ensuring that:
- non-existent user cannot be updated
- already existent user cannot be created again
- username needs to be unique

And in `user-follow-commands` module for checking existence of user that is expected to be followed or stopped followed.