### PR TITLE
#33 Implement on-boarding foundation

### DIFF
--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/LangsappApplication.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/LangsappApplication.kt
@@ -21,6 +21,7 @@ class LangsappApplication : Application() {
             keyValueStorage = object : KeyValueStorage {
                 private val map = mutableMapOf<String, String>()
                 override fun get(key: String): String? = map[key]
+                override fun getAll(): Map<String, String> = map
                 override fun set(key: String, value: String) = map.set(key, value)
                 override fun remove(key: String) {
                     map.remove(key)

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/MainActivity.kt
@@ -24,12 +24,18 @@ import androidx.compose.ui.platform.LocalContext
 import com.langsapp.android.identity.auth.AppAuthIdentityContract
 import com.langsapp.android.identity.auth.AuthResult
 import com.langsapp.android.logging.Log
+import com.langsapp.android.ui.content.ManageContentScreen
 import com.langsapp.android.ui.home.HomeScreen
+import com.langsapp.android.ui.settings.language.LanguageSettingsScreen
+import com.langsapp.android.ui.userprofile.upsert.UpsertProfileScreen
 import com.langsapp.architecture.CommonSideEffect
 import com.langsapp.architecture.StateTransition
+import com.langsapp.content.ManageContentState
 import com.langsapp.home.HomeNavigationSideEffect
 import com.langsapp.home.HomeState
 import com.langsapp.identity.IdentityAction
+import com.langsapp.settings.language.LanguageSettingsState
+import com.langsapp.userprofile.upsert.UpsertProfileState
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.isActive
 
@@ -114,6 +120,18 @@ fun AppUi(appViewModel: AppViewModel) {
                 is HomeState -> HomeScreen(
                     actionSender = appViewModel,
                     homeState = it.first as HomeState,
+                )
+                is LanguageSettingsState -> LanguageSettingsScreen(
+                    actionSender = appViewModel,
+                    state = it.first as LanguageSettingsState,
+                )
+                is UpsertProfileState -> UpsertProfileScreen(
+                    actionSender = appViewModel,
+                    state = it.first as UpsertProfileState,
+                )
+                is ManageContentState -> ManageContentScreen(
+                    actionSender = appViewModel,
+                    state = it.first as ManageContentState,
                 )
             }
         }

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/ContentLoadFailureScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/ContentLoadFailureScreen.kt
@@ -1,0 +1,25 @@
+package com.langsapp.android.ui.content
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.content.ManageContentAction
+import com.langsapp.content.ManageContentState
+
+@Composable
+fun ContentLoadFailureScreen(
+    actionSender: ActionSender<Action>,
+    state: ManageContentState.Failure,
+) {
+    Column {
+        Text("Manage content failure screen")
+        Button(
+            onClick = { actionSender.sendAction(ManageContentAction.DownloadUnitsTapped) },
+        ) {
+            Text("Retry download content")
+        }
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/ContentLoadedScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/ContentLoadedScreen.kt
@@ -1,0 +1,33 @@
+package com.langsapp.android.ui.content
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.content.ManageContentAction
+import com.langsapp.content.ManageContentState
+
+@Composable
+fun ContentLoadedScreen(
+    actionSender: ActionSender<Action>,
+    state: ManageContentState.Loaded,
+) {
+    Column {
+        Text("Manage content screen loaded")
+        Spacer(Modifier.height(32.dp))
+
+        Text("Has content: ${state.hasContent}")
+
+        Button(
+            onClick = { actionSender.sendAction(ManageContentAction.DownloadUnitsTapped) },
+        ) {
+            Text("Download content")
+        }
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/LoadingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/LoadingScreen.kt
@@ -1,0 +1,14 @@
+package com.langsapp.android.ui.content
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun LoadingScreen() {
+    Column {
+        Text("Manage content loading...")
+        CircularProgressIndicator()
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/ManageContentScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/content/ManageContentScreen.kt
@@ -1,0 +1,21 @@
+package com.langsapp.android.ui.content
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.content.ManageContentAction
+import com.langsapp.content.ManageContentState
+
+@Composable
+fun ManageContentScreen(
+    actionSender: ActionSender<Action>,
+    state: ManageContentState,
+) {
+    BackHandler { actionSender.sendAction(ManageContentAction.BackTapped) }
+    when (state) {
+        is ManageContentState.Loading -> LoadingScreen()
+        is ManageContentState.Loaded -> ContentLoadedScreen(actionSender, state)
+        is ManageContentState.Failure -> ContentLoadFailureScreen(actionSender, state)
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/home/LoadedHomeView.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/home/LoadedHomeView.kt
@@ -1,13 +1,20 @@
 package com.langsapp.android.ui.home
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.langsapp.architecture.Action
 import com.langsapp.architecture.ActionSender
+import com.langsapp.common.CommonResult
 import com.langsapp.home.HomeAction
 import com.langsapp.home.HomeState
+import com.langsapp.home.onboarding.OnBoardingInfo
+import com.langsapp.home.onboarding.UserProfileInfo
 
 @Composable
 internal fun LoadedHomeView(
@@ -15,11 +22,66 @@ internal fun LoadedHomeView(
     state: HomeState.Loaded,
 ) {
     Column {
+        val userProfileInfo = state.userProfileInfo
+        val onBoardingInfo = state.onBoardingInfo
+
         Text("Home loaded")
-        Button(onClick = {
-            actionSender.sendAction(HomeAction.SignUpTapped)
-        }) {
-            Text("Sign up")
+        Spacer(Modifier.height(32.dp))
+
+        Text("User profile info: $userProfileInfo")
+        if (userProfileInfo is CommonResult.Success) {
+            if (userProfileInfo.value is UserProfileInfo.Anonymous) {
+                Button(onClick = {
+                    actionSender.sendAction(HomeAction.SignUpTapped)
+                }) {
+                    Text("Sign up")
+                }
+            }
+        } else {
+            Text("Failed to load user profile info")
+        }
+
+        Spacer(Modifier.height(32.dp))
+
+        if (onBoardingInfo is CommonResult.Success) {
+            Text("On-boarding finished: ${onBoardingInfo.value.isFinished}")
+            Text("On-boarding sections:")
+            onBoardingInfo.value.sections.forEachIndexed { index, section ->
+                Spacer(Modifier.height(8.dp))
+                Text("Section ${index + 1}: ${section.rootStep}")
+                StepInfoView(actionSender, section.rootStep)
+                section.childSteps.forEach { stepInfo -> StepInfoView(actionSender, stepInfo) }
+            }
+        } else {
+            Text("Failed to load on-boarding info")
+        }
+    }
+}
+
+@Composable
+internal fun StepInfoView(
+    actionSender: ActionSender<Action>,
+    stepInfo: OnBoardingInfo.StepInfo,
+) {
+    Text("${stepInfo.step}, required: ${stepInfo.required}, done: ${stepInfo.done}, enabled: ${stepInfo.enabled}")
+    if (!stepInfo.done) {
+        Button(
+            onClick = {
+                when (stepInfo.step) {
+                    OnBoardingInfo.OnBoardingStep.SELECT_LANGUAGES -> actionSender.sendAction(HomeAction.SelectLanguagesTapped)
+                    OnBoardingInfo.OnBoardingStep.SIGN_UP -> actionSender.sendAction(HomeAction.SignUpTapped)
+                    OnBoardingInfo.OnBoardingStep.FILL_PROFILE -> actionSender.sendAction(HomeAction.UpsertProfileTapped)
+                    OnBoardingInfo.OnBoardingStep.DOWNLOAD_CONTENT -> actionSender.sendAction(HomeAction.DownloadContentTapped)
+                }
+            },
+            enabled = stepInfo.enabled,
+        ) {
+            when (stepInfo.step) {
+                OnBoardingInfo.OnBoardingStep.SELECT_LANGUAGES -> Text("Select languages")
+                OnBoardingInfo.OnBoardingStep.SIGN_UP -> Text("Sign up")
+                OnBoardingInfo.OnBoardingStep.FILL_PROFILE -> Text("Fill profile")
+                OnBoardingInfo.OnBoardingStep.DOWNLOAD_CONTENT -> Text("Download content")
+            }
         }
     }
 }

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/FailureScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/FailureScreen.kt
@@ -1,0 +1,35 @@
+package com.langsapp.android.ui.settings.language
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.langsapp.android.logging.Log
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.settings.language.LanguageSettingsAction
+import com.langsapp.settings.language.LanguageSettingsState
+
+@Composable
+internal fun FailureScreen(
+    actionSender: ActionSender<Action>,
+    state: LanguageSettingsState.DataLoadingFailure,
+) {
+    Column {
+        Text("Language settings failure")
+        Spacer(Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                Log.d("Retry tapped")
+                actionSender.sendAction(LanguageSettingsAction.RetryTapped)
+            },
+        ) {
+            Text("Retry")
+        }
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/InputScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/InputScreen.kt
@@ -1,0 +1,276 @@
+package com.langsapp.android.ui.settings.language
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.langsapp.android.logging.Log
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.settings.language.LanguageSettingsAction
+import com.langsapp.settings.language.LanguageSettingsState
+
+@Composable
+internal fun InputScreen(
+    actionSender: ActionSender<Action>,
+    state: LanguageSettingsState.Input,
+) {
+    Column {
+        Text("Language settings")
+        Spacer(Modifier.height(16.dp))
+
+        val chips = remember { state.availableLanguages.map { it.code } }
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(all = 16.dp),
+        ) {
+            Text(text = "Learn language")
+            val learnLanguageState = rememberChipSelectorState(
+                chips = chips,
+                selectedChips = state.learnLanguage?.let { listOf(it.code) } ?: emptyList(),
+            )
+            ChipsSelector(
+                state = learnLanguageState,
+                modifier = Modifier.fillMaxWidth(),
+                onChipTapped = {
+                    val learnLanguage = learnLanguageState.selectedChips.firstOrNull()
+                    Log.d("Learn language chip tapped, selected: $learnLanguage")
+                    if (learnLanguage != null) {
+                        Log.d("Learn language selected: $learnLanguage")
+                        actionSender.sendAction(
+                            LanguageSettingsAction.LearnLanguageChanged(
+                                state.availableLanguages.first { it.code == learnLanguage },
+                            ),
+                        )
+                    } else {
+                        Log.d("Learn language deselected")
+                    }
+                },
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Text(text = "Base language")
+            val baseLanguageState = rememberChipSelectorState(
+                chips = chips,
+                selectedChips = state.baseLanguage?.let { listOf(it.code) } ?: emptyList(),
+            )
+            ChipsSelector(
+                state = baseLanguageState,
+                modifier = Modifier.fillMaxWidth(),
+                onChipTapped = {
+                    val baseLanguage = baseLanguageState.selectedChips.firstOrNull()
+                    Log.d("Base language chip tapped, selected: $baseLanguage")
+                    if (baseLanguage != null) {
+                        Log.d("Base language selected: $baseLanguage")
+                        actionSender.sendAction(
+                            LanguageSettingsAction.BaseLanguageChanged(
+                                state.availableLanguages.first { it.code == baseLanguage },
+                            ),
+                        )
+                    } else {
+                        Log.d("Base language deselected")
+                    }
+                },
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Text(text = "Support language")
+            val supportLanguageState = rememberChipSelectorState(
+                chips = chips,
+                selectedChips = state.supportLanguage?.let { listOf(it.code) } ?: emptyList(),
+            )
+            ChipsSelector(
+                state = supportLanguageState,
+                modifier = Modifier.fillMaxWidth(),
+                onChipTapped = {
+                    val supportLanguage = supportLanguageState.selectedChips.firstOrNull()
+                    Log.d("Support language chip tapped, selected: $supportLanguage")
+                    if (supportLanguage != null) {
+                        Log.d("Support language selected: $supportLanguage")
+                        actionSender.sendAction(
+                            LanguageSettingsAction.SupportLanguageChanged(
+                                state.availableLanguages.first { it.code == supportLanguage },
+                            ),
+                        )
+                    } else {
+                        Log.d("Support language deselected")
+                    }
+                },
+            )
+
+            Button(
+                onClick = {
+                    Log.d("Confirm tapped")
+                    actionSender.sendAction(LanguageSettingsAction.ConfirmTapped)
+                },
+                enabled = state.isInputCorrect,
+            ) {
+                Text("Confirm")
+            }
+        }
+    }
+}
+
+enum class SelectionMode(val index: Int) {
+    Single(0),
+    Multiple(1),
+    ;
+
+    companion object {
+        fun fromIndex(index: Int) = entries.firstOrNull { it.index == index } ?: Single
+    }
+}
+
+@Stable
+interface ChipSelectorState {
+    val chips: List<String>
+    val selectedChips: List<String>
+
+    fun onChipClick(chip: String)
+    fun isSelected(chip: String): Boolean
+}
+
+class ChipSelectorStateImpl(
+    override val chips: List<String>,
+    selectedChips: List<String> = emptyList(),
+    val mode: SelectionMode = SelectionMode.Single,
+) : ChipSelectorState {
+    override var selectedChips by mutableStateOf(selectedChips)
+
+    override fun onChipClick(chip: String) {
+        if (mode == SelectionMode.Single) {
+            if (!selectedChips.contains(chip)) {
+                selectedChips = listOf(chip)
+            }
+        } else {
+            selectedChips = if (selectedChips.contains(chip)) {
+                selectedChips - chip
+            } else {
+                selectedChips + chip
+            }
+        }
+    }
+
+    override fun isSelected(chip: String): Boolean = selectedChips.contains(chip)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ChipSelectorStateImpl
+
+        if (chips != other.chips) return false
+        if (mode != other.mode) return false
+        if (selectedChips != other.selectedChips) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = chips.hashCode()
+        result = 31 * result + mode.hashCode()
+        result = 31 * result + selectedChips.hashCode()
+        return result
+    }
+
+    companion object {
+        val saver = Saver<ChipSelectorStateImpl, List<*>>(
+            save = { state ->
+                buildList {
+                    add(state.chips.size)
+                    addAll(state.chips)
+                    add(state.selectedChips.size)
+                    addAll(state.selectedChips)
+                    add(state.mode.index)
+                }
+            },
+            restore = { items ->
+                var index = 0
+                val chipsSize = items[index++] as Int
+                val chips = List(chipsSize) {
+                    items[index++] as String
+                }
+                val selectedSize = items[index++] as Int
+                val selectedChips = List(selectedSize) {
+                    items[index++] as String
+                }
+                val mode = SelectionMode.fromIndex(items[index] as Int)
+                ChipSelectorStateImpl(
+                    chips = chips,
+                    selectedChips = selectedChips,
+                    mode = mode,
+                )
+            },
+        )
+    }
+}
+
+@Composable
+fun rememberChipSelectorState(
+    chips: List<String>,
+    selectedChips: List<String> = emptyList(),
+    mode: SelectionMode = SelectionMode.Single,
+): ChipSelectorState {
+    if (chips.isEmpty()) error("No chips provided")
+    if (mode == SelectionMode.Single && selectedChips.size > 1) {
+        error("Single choice can only have 1 pre-selected chip")
+    }
+
+    return rememberSaveable(
+        saver = ChipSelectorStateImpl.saver,
+    ) {
+        ChipSelectorStateImpl(
+            chips,
+            selectedChips,
+            mode,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ChipsSelector(
+    onChipTapped: () -> Unit,
+    state: ChipSelectorState,
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(16.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(16.dp),
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = horizontalArrangement,
+        verticalArrangement = verticalArrangement,
+    ) {
+        state.chips.forEach { chip ->
+            FilterChip(
+                selected = state.isSelected(chip),
+                onClick = {
+                    state.onChipClick(chip)
+                    onChipTapped()
+                },
+                label = {
+                    Text(chip)
+                },
+            )
+        }
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/LanguageSettingsScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/LanguageSettingsScreen.kt
@@ -1,0 +1,21 @@
+package com.langsapp.android.ui.settings.language
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.settings.language.LanguageSettingsAction
+import com.langsapp.settings.language.LanguageSettingsState
+
+@Composable
+internal fun LanguageSettingsScreen(
+    actionSender: ActionSender<Action>,
+    state: LanguageSettingsState,
+) {
+    BackHandler { actionSender.sendAction(LanguageSettingsAction.BackTapped) }
+    when (state) {
+        is LanguageSettingsState.Loading -> LoadingScreen()
+        is LanguageSettingsState.Input -> InputScreen(actionSender, state)
+        is LanguageSettingsState.DataLoadingFailure -> FailureScreen(actionSender, state)
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/LoadingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/settings/language/LoadingScreen.kt
@@ -1,0 +1,14 @@
+package com.langsapp.android.ui.settings.language
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun LoadingScreen() {
+    Column {
+        Text("Language settings loading...")
+        CircularProgressIndicator()
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/userprofile/upsert/InputScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/userprofile/upsert/InputScreen.kt
@@ -1,0 +1,55 @@
+package com.langsapp.android.ui.userprofile.upsert
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.langsapp.android.logging.Log
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.userprofile.upsert.UpsertProfileAction
+import com.langsapp.userprofile.upsert.UpsertProfileState
+
+@Composable
+internal fun InputScreen(
+    actionSender: ActionSender<Action>,
+    state: UpsertProfileState.Input,
+) {
+    Column {
+        Text("Upsert profile")
+        Spacer(Modifier.height(16.dp))
+
+        Text("Current profile: ${state.currentProfile}")
+        Spacer(Modifier.height(16.dp))
+
+        var username by remember { mutableStateOf(TextFieldValue(state.currentProfile?.username ?: "")) }
+        TextField(
+            value = username,
+            onValueChange = {
+                username = it
+            },
+            label = { Text(text = "Username") },
+            placeholder = { Text(text = "Type username here") },
+        )
+
+        Button(
+            onClick = {
+                Log.d("Confirm tapped")
+                actionSender.sendAction(UpsertProfileAction.ConfirmTapped(username.text))
+            },
+            enabled = true,
+        ) {
+            Text("Confirm")
+        }
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/userprofile/upsert/LoadingScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/userprofile/upsert/LoadingScreen.kt
@@ -1,0 +1,14 @@
+package com.langsapp.android.ui.userprofile.upsert
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun LoadingScreen() {
+    Column {
+        Text("Upserting profile...")
+        CircularProgressIndicator()
+    }
+}

--- a/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/userprofile/upsert/UpsertProfileScreen.kt
+++ b/mobile/androidApp/src/main/kotlin/com/langsapp/android/ui/userprofile/upsert/UpsertProfileScreen.kt
@@ -1,0 +1,20 @@
+package com.langsapp.android.ui.userprofile.upsert
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import com.langsapp.architecture.Action
+import com.langsapp.architecture.ActionSender
+import com.langsapp.userprofile.upsert.UpsertProfileAction
+import com.langsapp.userprofile.upsert.UpsertProfileState
+
+@Composable
+internal fun UpsertProfileScreen(
+    actionSender: ActionSender<Action>,
+    state: UpsertProfileState,
+) {
+    BackHandler { actionSender.sendAction(UpsertProfileAction.BackTapped) }
+    when (state) {
+        is UpsertProfileState.Loading -> LoadingScreen()
+        is UpsertProfileState.Input -> InputScreen(actionSender, state)
+    }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/architecture/SideEffect.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/architecture/SideEffect.kt
@@ -6,5 +6,6 @@ sealed interface CommonSideEffect : SideEffect {
     abstract class NavigationSideEffect(direction: Direction) : CommonSideEffect {
         enum class Direction { BACKWARD, FORWARD }
     }
+    data object Exit : NavigationSideEffect(Direction.BACKWARD)
     data class ShowPopUpMessage(val message: String) : CommonSideEffect
 }

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/common/CommonResult.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/common/CommonResult.kt
@@ -1,0 +1,32 @@
+package com.langsapp.common
+
+/**
+ * Class similar to [Result] that looks more elegant when used from iOS codebase and provide possibility to define
+ * custom [FailureType] for better compile-type safety when used.
+ */
+sealed class CommonResult<SuccessType, FailureType> {
+    data class Success<SuccessType, FailureType>(val value: SuccessType) : CommonResult<SuccessType, FailureType>()
+    data class Failure<SuccessType, FailureType>(val error: FailureType) : CommonResult<SuccessType, FailureType>()
+
+    fun fold(
+        onSuccess: (SuccessType) -> (Unit),
+        onFailure: (FailureType) -> (Unit)
+    ) {
+        when (this) {
+            is Success -> onSuccess(value)
+            is Failure -> onFailure(error)
+        }
+    }
+
+    fun getOrNull(): SuccessType? =
+        when (this) {
+            is Success -> value
+            is Failure -> null
+        }
+
+    fun errorOrNull(): FailureType? =
+        when (this) {
+            is Success -> null
+            is Failure -> error
+        }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/common/CommonResultMapping.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/common/CommonResultMapping.kt
@@ -1,0 +1,9 @@
+package com.langsapp.common
+
+fun <SuccessType, FailureType> Result<SuccessType>.mapToCommonResult(
+    errorMapping: (Throwable) -> FailureType
+): CommonResult<SuccessType, FailureType> =
+    fold(
+        onSuccess = { CommonResult.Success(it) },
+        onFailure = { CommonResult.Failure(errorMapping(it)) }
+    )

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/config/KeyValueStorage.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/config/KeyValueStorage.kt
@@ -3,6 +3,8 @@ package com.langsapp.config
 interface KeyValueStorage {
     fun get(key: String): String?
 
+    fun getAll(): Map<String, String>
+
     fun set(key: String, value: String)
 
     fun remove(key: String)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentAction.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentAction.kt
@@ -1,0 +1,17 @@
+package com.langsapp.content
+
+import com.langsapp.architecture.Action
+
+sealed class ManageContentAction : Action {
+    data class DataLoaded(
+        val unitsCount: Int,
+    ) : ManageContentAction()
+    data object DataLoadingFailed : ManageContentAction()
+    data object RetryTapped : ManageContentAction()
+    data object DownloadUnitsTapped : ManageContentAction()
+    data object DownloadUnitsSucceeded : ManageContentAction()
+    data class DownloadUnitsFailed(
+        val previousState: ManageContentState.Loaded,
+    ) : ManageContentAction()
+    data object BackTapped : ManageContentAction()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentRepository.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentRepository.kt
@@ -1,0 +1,29 @@
+package com.langsapp.content
+
+import com.langsapp.config.Log
+import com.langsapp.data.ContentDatabase
+import com.langsapp.data.ContentService
+import com.langsapp.model.LanguageSetting
+import com.langsapp.model.content.ContentUnit
+
+class ManageContentRepository(
+    private val contentService: ContentService,
+    private val contentDatabase: ContentDatabase,
+) {
+
+    suspend fun getAllUnits(languageSetting: LanguageSetting): Result<List<ContentUnit>> =
+        runCatching {
+            contentDatabase.getAllUnits(languageSetting)
+        }
+            .onFailure {
+                Log.d("Failed to get content units: $it")
+            }
+
+    suspend fun downloadUnits(languageSetting: LanguageSetting): Result<Unit> =
+        runCatching {
+            contentService.getContentUnits(languageSetting)
+        }
+            .mapCatching {
+                contentDatabase.insertUnits(languageSetting, it)
+            }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentSideEffect.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentSideEffect.kt
@@ -1,0 +1,10 @@
+package com.langsapp.content
+
+import com.langsapp.architecture.SideEffect
+
+sealed interface ManageContentSideEffect {
+    data object LoadContentData : SideEffect
+    data class DownloadUnits(
+        val previousState: ManageContentState.Loaded,
+    ) : SideEffect
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentState.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentState.kt
@@ -1,0 +1,11 @@
+package com.langsapp.content
+
+import com.langsapp.architecture.State
+
+sealed class ManageContentState : State {
+    data object Loading : ManageContentState()
+    data class Loaded(
+        val hasContent: Boolean,
+    ) : ManageContentState()
+    data object Failure : ManageContentState()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentStateManager.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/content/ManageContentStateManager.kt
@@ -1,0 +1,89 @@
+package com.langsapp.content
+
+import com.langsapp.architecture.ActionResult
+import com.langsapp.architecture.CommonSideEffect
+import com.langsapp.architecture.StateManager
+import com.langsapp.config.Log
+import com.langsapp.model.LanguageSetting
+
+class ManageContentStateManager(
+    val languageSetting: LanguageSetting,
+    private val manageContentRepository: ManageContentRepository,
+) : StateManager<ManageContentState, ManageContentAction>(
+    initialState = ManageContentState.Loading,
+    initialSideEffects = ArrayDeque(listOf(ManageContentSideEffect.LoadContentData)),
+    handleAction = { previousState, action ->
+        when (action) {
+            is ManageContentAction.DataLoaded -> ActionResult(
+                newState = ManageContentState.Loaded(
+                    hasContent = action.unitsCount > 0,
+                ),
+            )
+
+            ManageContentAction.DataLoadingFailed -> ActionResult(
+                newState = ManageContentState.Failure,
+            )
+
+            ManageContentAction.RetryTapped -> ActionResult(
+                newState = ManageContentState.Loading,
+                sideEffects = listOf(ManageContentSideEffect.LoadContentData),
+            )
+
+            ManageContentAction.DownloadUnitsTapped -> when (previousState) {
+                is ManageContentState.Loaded -> ActionResult(
+                    sideEffects = listOf(ManageContentSideEffect.DownloadUnits(previousState)),
+                )
+                else -> {
+                    Log.e("Unexpected state: $previousState for action: $action")
+                    ActionResult()
+                }
+            }
+
+            ManageContentAction.BackTapped -> ActionResult(sideEffects = listOf(CommonSideEffect.Exit))
+            is ManageContentAction.DownloadUnitsFailed -> ActionResult(
+                newState = action.previousState,
+                sideEffects = listOf(
+                    // TODO Replace with correctly localised text
+                    CommonSideEffect.ShowPopUpMessage("Something went wrong :/ "),
+                ),
+            )
+
+            ManageContentAction.DownloadUnitsSucceeded -> ActionResult(
+                sideEffects = listOf(
+                    // TODO Replace with correctly localised text
+                    CommonSideEffect.ShowPopUpMessage("Content downloaded success"),
+                    CommonSideEffect.Exit,
+                ),
+            )
+        }
+    },
+    handleSideEffect = {
+        when (it) {
+            is ManageContentSideEffect.LoadContentData ->
+                manageContentRepository
+                    .getAllUnits(languageSetting)
+                    .fold(
+                        onSuccess = { units ->
+                            ManageContentAction.DataLoaded(unitsCount = units.size)
+                        },
+                        onFailure = {
+                            ManageContentAction.DataLoadingFailed
+                        },
+                    )
+
+            is ManageContentSideEffect.DownloadUnits ->
+                manageContentRepository
+                    .downloadUnits(languageSetting)
+                    .fold(
+                        onSuccess = {
+                            ManageContentAction.DownloadUnitsSucceeded
+                        },
+                        onFailure = { _ ->
+                            ManageContentAction.DownloadUnitsFailed(it.previousState)
+                        },
+                    )
+
+            else -> null
+        }
+    },
+)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/data/ContentDatabase.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/data/ContentDatabase.kt
@@ -1,0 +1,14 @@
+package com.langsapp.data
+
+import com.langsapp.model.LanguageSetting
+import com.langsapp.model.content.ContentUnit
+
+class ContentDatabase {
+    private var units: List<ContentUnit> = mutableListOf()
+
+    fun getAllUnits(languageSetting: LanguageSetting) = units
+
+    fun insertUnits(languageSetting: LanguageSetting, units: List<ContentUnit>) {
+        this.units = units
+    }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/data/ContentService.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/data/ContentService.kt
@@ -1,0 +1,12 @@
+package com.langsapp.data
+
+import com.langsapp.model.Language
+import com.langsapp.model.LanguageSetting
+import com.langsapp.model.content.ContentUnit
+
+interface ContentService {
+
+    suspend fun fetchAvailableLanguages(): List<Language>
+
+    suspend fun getContentUnits(languageSetting: LanguageSetting): List<ContentUnit>
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/data/MockContentService.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/data/MockContentService.kt
@@ -1,0 +1,39 @@
+package com.langsapp.data
+
+import com.langsapp.model.Language
+import com.langsapp.model.LanguageSetting
+import com.langsapp.model.content.ContentUnit
+import com.langsapp.model.content.TranslationData
+
+class MockContentService : ContentService {
+
+    override suspend fun fetchAvailableLanguages(): List<Language> =
+        listOf(
+            Language("en"),
+            Language("de"),
+            Language("pl"),
+            Language("ru"),
+        )
+
+    override suspend fun getContentUnits(languageSetting: LanguageSetting): List<ContentUnit> =
+        listOf(
+            ContentUnit(
+                id = "1",
+                translationData = TranslationData(
+                    languageSetting = languageSetting,
+                    learnLanguageText = "one",
+                    baseLanguageText = "jeden",
+                    supportLanguageText = null,
+                ),
+            ),
+            ContentUnit(
+                id = "2",
+                translationData = TranslationData(
+                    languageSetting = languageSetting,
+                    learnLanguageText = "two",
+                    baseLanguageText = "dwa",
+                    supportLanguageText = null,
+                ),
+            ),
+        )
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/data/MockUserProfileService.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/data/MockUserProfileService.kt
@@ -1,0 +1,39 @@
+package com.langsapp.data
+
+import com.langsapp.config.Log
+import com.langsapp.model.UserProfile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+class MockUserProfileService : UserProfileService {
+    private val userProfiles = mutableMapOf<String, UserProfile>()
+
+    override suspend fun createUserProfile(accessToken: String, userId: String) {
+        delay(500)
+        userProfiles[accessToken] = UserProfile()
+    }
+
+    override suspend fun getUserProfile(accessToken: String): UserProfile? =
+        withContext(Dispatchers.IO) {
+            Log.d("$this getUserProfile")
+            delay(500)
+            userProfiles[accessToken]
+        }
+
+    override suspend fun upsertUserProperties(
+        accessToken: String,
+        properties: List<UserProfileService.UserProperty>,
+    ) =
+        userProfiles[accessToken]?.let { profile ->
+            Log.d("$this upsertUserProperties, properties: $properties")
+            delay(500)
+            properties.forEach {
+                userProfiles[accessToken] = when (it) {
+                    is UserProfileService.UserProperty.LanguageSetting -> profile.copy(languageSetting = it.setting)
+                    is UserProfileService.UserProperty.Username -> profile.copy(username = it.username)
+                }
+            }
+        } ?: error("Profile not created")
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/data/UserProfileService.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/data/UserProfileService.kt
@@ -1,0 +1,25 @@
+package com.langsapp.data
+
+import com.langsapp.model.UserProfile
+
+interface UserProfileService {
+
+    sealed class UserProperty {
+        data class LanguageSetting(val setting: com.langsapp.model.LanguageSetting) : UserProperty()
+        data class Username(val username: String) : UserProperty()
+    }
+
+    suspend fun createUserProfile(
+        accessToken: String,
+        userId: String,
+    )
+
+    suspend fun getUserProfile(
+        accessToken: String,
+    ): UserProfile?
+
+    suspend fun upsertUserProperties(
+        accessToken: String,
+        properties: List<UserProperty>,
+    )
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeAction.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeAction.kt
@@ -1,10 +1,22 @@
 package com.langsapp.home
 
 import com.langsapp.architecture.Action
+import com.langsapp.common.CommonResult
+import com.langsapp.home.onboarding.OnBoardingInfo
+import com.langsapp.home.onboarding.UserProfileInfo
 
 sealed class HomeAction : Action {
     data object SkipTapped : HomeAction()
     data object SignUpTapped : HomeAction()
     data object SignUpFinished : HomeAction()
-    data object HomeDataLoaded : HomeAction()
+    data object UpsertProfileTapped : HomeAction()
+    data object UpsertProfileFinished : HomeAction()
+    data object SelectLanguagesTapped : HomeAction()
+    data object SelectLanguagesFinished : HomeAction()
+    data object DownloadContentTapped : HomeAction()
+    data object DownloadContentFinished : HomeAction()
+    data class HomeDataLoaded(
+        val userProfileInfo: CommonResult<UserProfileInfo, Unit>,
+        val onBoardingInfo: CommonResult<OnBoardingInfo, Unit>,
+    ) : HomeAction()
 }

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeRepository.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeRepository.kt
@@ -1,18 +1,34 @@
 package com.langsapp.home
 
+import com.langsapp.common.CommonResult
+import com.langsapp.common.mapToCommonResult
 import com.langsapp.config.KeyValueStorage
 import com.langsapp.config.Log
+import com.langsapp.home.onboarding.OnBoardingInfo
+import com.langsapp.home.onboarding.OnBoardingRepository
+import com.langsapp.home.onboarding.UserProfileInfo
+import com.langsapp.home.onboarding.UserProfileRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 
 class HomeRepository(
     private val keyValueStorage: KeyValueStorage,
+    private val userProfileRepository: UserProfileRepository,
+    private val onBoardingRepository: OnBoardingRepository,
 ) {
     suspend fun loadHomeScreen(): HomeScreenData =
         withContext(Dispatchers.IO) {
             Log.d("")
-            HomeScreenData
+            HomeScreenData(
+                userProfileInfo =
+                userProfileRepository
+                    .provideProfileInfo()
+                    .mapToCommonResult { },
+                onBoardingInfo = onBoardingRepository
+                    .provideOnBoardingInfo()
+                    .mapToCommonResult { },
+            )
         }
 
     fun hasShownWelcome(): Boolean = keyValueStorage.get(WELCOME_SCREEN_SHOWN_KEY) == "true"
@@ -21,7 +37,10 @@ class HomeRepository(
         keyValueStorage.set(WELCOME_SCREEN_SHOWN_KEY, if (hasShown) "true" else "false")
     }
 
-    data object HomeScreenData
+    data class HomeScreenData(
+        val userProfileInfo: CommonResult<UserProfileInfo, Unit>,
+        val onBoardingInfo: CommonResult<OnBoardingInfo, Unit>,
+    )
 
     companion object {
         private const val WELCOME_SCREEN_SHOWN_KEY = "WELCOME_SCREEN_SHOWN_KEY"

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeSideEffect.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeSideEffect.kt
@@ -2,7 +2,9 @@ package com.langsapp.home
 
 import com.langsapp.architecture.CommonSideEffect
 import com.langsapp.architecture.SideEffect
+import com.langsapp.home.onboarding.UserProfileInfo
 import com.langsapp.identity.auth.AuthConfig
+import com.langsapp.model.LanguageSetting
 
 sealed interface HomeSideEffect {
     data object LoadHomeDataSideEffect : SideEffect
@@ -10,4 +12,11 @@ sealed interface HomeSideEffect {
 
 sealed class HomeNavigationSideEffect(direction: Direction) : CommonSideEffect.NavigationSideEffect(direction) {
     data class SignUp(val authConfig: AuthConfig) : HomeNavigationSideEffect(Direction.FORWARD)
+    data object SelectLanguages : HomeNavigationSideEffect(Direction.FORWARD)
+    data class CreateProfile(
+        val userProfileInfo: UserProfileInfo,
+    ) : HomeNavigationSideEffect(Direction.FORWARD)
+    data class ManageContent(
+        val languageSetting: LanguageSetting,
+    ) : HomeNavigationSideEffect(Direction.FORWARD)
 }

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeState.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeState.kt
@@ -1,10 +1,16 @@
 package com.langsapp.home
 
 import com.langsapp.architecture.State
+import com.langsapp.common.CommonResult
+import com.langsapp.home.onboarding.OnBoardingInfo
+import com.langsapp.home.onboarding.UserProfileInfo
 import com.langsapp.home.welcome.WelcomeSlide
 
 sealed class HomeState : State {
     data class Welcome(val slides: List<WelcomeSlide>) : HomeState()
     data object Loading : HomeState()
-    data object Loaded : HomeState()
+    data class Loaded(
+        val userProfileInfo: CommonResult<UserProfileInfo, Unit>,
+        val onBoardingInfo: CommonResult<OnBoardingInfo, Unit>,
+    ) : HomeState()
 }

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeStateManager.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/HomeStateManager.kt
@@ -2,9 +2,14 @@ package com.langsapp.home
 
 import com.langsapp.architecture.ActionResult
 import com.langsapp.architecture.StateManager
+import com.langsapp.config.Log
+import com.langsapp.content.ManageContentState
+import com.langsapp.home.onboarding.UserProfileInfo
 import com.langsapp.home.welcome.WelcomeSlide
 import com.langsapp.identity.IdentityState
 import com.langsapp.identity.auth.AuthConfig
+import com.langsapp.settings.language.LanguageSettingsState
+import com.langsapp.userprofile.upsert.UpsertProfileState
 
 class HomeStateManager(
     welcomeSlides: List<WelcomeSlide>,
@@ -23,10 +28,37 @@ class HomeStateManager(
                 )
             }
 
-            HomeAction.SignUpFinished -> ActionResult()
+            HomeAction.SignUpFinished -> {
+                if (currentState is HomeState.Loaded &&
+                    currentState.userProfileInfo.getOrNull() is UserProfileInfo.Anonymous
+                ) {
+                    // Refresh home data when user really signed in
+                    ActionResult(
+                        newState = HomeState.Loading,
+                        sideEffects = ArrayDeque(
+                            listOf(
+                                HomeSideEffect.LoadHomeDataSideEffect,
+                            ),
+                        ),
+                    )
+                } else {
+                    ActionResult()
+                }
+            }
+
+            HomeAction.UpsertProfileFinished,
+            HomeAction.SelectLanguagesFinished,
+            HomeAction.DownloadContentFinished,
+            -> ActionResult(
+                sideEffects = ArrayDeque(
+                    listOf(
+                        HomeSideEffect.LoadHomeDataSideEffect,
+                    ),
+                ),
+            )
 
             is HomeAction.HomeDataLoaded -> ActionResult(
-                newState = HomeState.Loaded,
+                newState = HomeState.Loaded(action.userProfileInfo, action.onBoardingInfo),
             )
 
             HomeAction.SignUpTapped -> ActionResult(
@@ -38,6 +70,51 @@ class HomeStateManager(
                     ),
                 ),
             )
+
+            HomeAction.SelectLanguagesTapped -> ActionResult(sideEffects = ArrayDeque(listOf(HomeNavigationSideEffect.SelectLanguages)))
+            HomeAction.UpsertProfileTapped -> {
+                when (currentState) {
+                    is HomeState.Loaded -> {
+                        val userProfile = currentState.userProfileInfo.getOrNull()
+                        if (userProfile == null) {
+                            Log.e("Trying to open create profile without profile data")
+                            ActionResult()
+                        } else {
+                            ActionResult(
+                                sideEffects = ArrayDeque(listOf(HomeNavigationSideEffect.CreateProfile(userProfile))),
+                            )
+                        }
+                    }
+
+                    else -> {
+                        Log.e("Trying to open create profile from invalid state: $currentState")
+                        ActionResult()
+                    }
+                }
+            }
+
+            HomeAction.DownloadContentTapped ->
+                when (currentState) {
+                    is HomeState.Loaded -> {
+                        val languageSetting =
+                            currentState.userProfileInfo.getOrNull()?.languageSetting()
+                        if (languageSetting == null) {
+                            Log.e("Trying to open content download without language setting")
+                            ActionResult()
+                        } else {
+                            ActionResult(
+                                sideEffects = ArrayDeque(
+                                    listOf(HomeNavigationSideEffect.ManageContent(languageSetting)),
+                                ),
+                            )
+                        }
+                    }
+
+                    else -> {
+                        Log.e("Trying to open content download from invalid state: $currentState")
+                        ActionResult()
+                    }
+                }
         }
     },
     handleSideEffect = { sideEffect ->
@@ -46,7 +123,10 @@ class HomeStateManager(
                 homeRepository
                     .loadHomeScreen()
                     .let {
-                        HomeAction.HomeDataLoaded
+                        HomeAction.HomeDataLoaded(
+                            userProfileInfo = it.userProfileInfo,
+                            onBoardingInfo = it.onBoardingInfo,
+                        )
                     }
 
             else -> null
@@ -57,6 +137,15 @@ class HomeStateManager(
             // Identity signed in for the first time
             newState is IdentityState.SignedIn && previousState !is IdentityState.SignedIn ->
                 HomeAction.SignUpFinished
+            // Navigating back from language settings
+            newState is HomeState && previousState is LanguageSettingsState ->
+                HomeAction.SelectLanguagesFinished
+
+            newState is HomeState && previousState is UpsertProfileState ->
+                HomeAction.UpsertProfileFinished
+
+            newState is HomeState && previousState is ManageContentState.Loaded ->
+                HomeAction.DownloadContentFinished
 
             else -> null
         }

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/OnBoardingInfo.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/OnBoardingInfo.kt
@@ -1,0 +1,121 @@
+package com.langsapp.home.onboarding
+
+class OnBoardingInfo private constructor(
+    val sections: List<OnBoardingSection>,
+) {
+    val isFinished: Boolean =
+        sections.none {
+            (it.rootStep.required && !it.rootStep.done)
+                || it.childSteps.any { stepInfo ->
+                (stepInfo.required && !stepInfo.done)
+            }
+        }
+
+    enum class OnBoardingStep {
+        SELECT_LANGUAGES,
+        SIGN_UP,
+        FILL_PROFILE,
+        DOWNLOAD_CONTENT,
+    }
+
+    /**
+     * @param required Indicates if the step is required to do before using the app
+     * @param done Indicates if the step is done already
+     * @param enabled Indicates if in current state the step can be performed.
+     * For example user can't add profile info if they didn't sign up before
+     */
+    data class StepInfo(
+        val step: OnBoardingStep,
+        val required: Boolean = false,
+        val done: Boolean = false,
+        val enabled: Boolean = true,
+    )
+
+    data class OnBoardingSection(val rootStep: StepInfo, val childSteps: List<StepInfo> = emptyList())
+
+    companion object {
+        fun createForFreshUser(): OnBoardingInfo = OnBoardingInfo(
+            sections = listOf(
+                OnBoardingSection(
+                    rootStep = StepInfo(OnBoardingStep.SELECT_LANGUAGES, required = true),
+                    childSteps = listOf(
+                        StepInfo(step = OnBoardingStep.DOWNLOAD_CONTENT, required = true, enabled = false),
+                    ),
+                ),
+                OnBoardingSection(
+                    rootStep = StepInfo(step = OnBoardingStep.SIGN_UP),
+                    childSteps = listOf(StepInfo(OnBoardingStep.FILL_PROFILE, enabled = false)),
+                ),
+            ),
+        )
+
+        fun OnBoardingInfo.finishStep(step: OnBoardingStep): OnBoardingInfo =
+            markStepDone(step)
+                .let {
+                    when (step) {
+                        OnBoardingStep.SELECT_LANGUAGES ->
+                            it
+                                .markStepEnabled(OnBoardingStep.DOWNLOAD_CONTENT)
+
+                        OnBoardingStep.DOWNLOAD_CONTENT -> it
+                        OnBoardingStep.SIGN_UP ->
+                            it
+                                .markStepEnabled(OnBoardingStep.FILL_PROFILE)
+                                .markStepRequired(OnBoardingStep.FILL_PROFILE)
+
+                        OnBoardingStep.FILL_PROFILE -> it
+                    }
+                }
+
+        private fun OnBoardingInfo.markStepDone(step: OnBoardingStep) = OnBoardingInfo(
+            sections = sections.map { section ->
+                when {
+                    section.rootStep.step == step -> section.copy(rootStep = section.rootStep.copy(done = true))
+                    else -> section.copy(
+                        childSteps = section.childSteps.map {
+                            if (it.step == step) {
+                                it.copy(done = true)
+                            } else {
+                                it
+                            }
+                        },
+                    )
+                }
+            },
+        )
+
+        private fun OnBoardingInfo.markStepRequired(step: OnBoardingStep) = OnBoardingInfo(
+            sections = sections.map { section ->
+                when {
+                    section.rootStep.step == step -> section.copy(rootStep = section.rootStep.copy(required = true))
+                    else -> section.copy(
+                        childSteps = section.childSteps.map {
+                            if (it.step == step) {
+                                it.copy(required = true)
+                            } else {
+                                it
+                            }
+                        },
+                    )
+                }
+            },
+        )
+
+        private fun OnBoardingInfo.markStepEnabled(step: OnBoardingStep) = OnBoardingInfo(
+            sections = sections.map { section ->
+                when {
+                    section.rootStep.step == step -> section.copy(rootStep = section.rootStep.copy(enabled = true))
+                    else -> section.copy(
+                        childSteps = section.childSteps.map {
+                            if (it.step == step) {
+                                it.copy(enabled = true)
+                            } else {
+                                it
+                            }
+                        },
+                    )
+                }
+            },
+        )
+    }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/OnBoardingRepository.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/OnBoardingRepository.kt
@@ -1,0 +1,56 @@
+package com.langsapp.home.onboarding
+
+import com.langsapp.content.ManageContentRepository
+import com.langsapp.home.onboarding.OnBoardingInfo.Companion.finishStep
+
+class OnBoardingRepository(
+    private val userProfileRepository: UserProfileRepository,
+    private val contentRepository: ManageContentRepository,
+) {
+    suspend fun provideOnBoardingInfo(): Result<OnBoardingInfo> {
+        val profileInfo =
+            userProfileRepository
+                .provideProfileInfo()
+                .fold(
+                    onSuccess = { it },
+                    onFailure = { return Result.failure(it) },
+                )
+        return Result.success(
+            OnBoardingInfo
+                .createForFreshUser()
+                .let {
+                    when (profileInfo) {
+                        is UserProfileInfo.SignedIn ->
+                            it
+                                .finishStep(OnBoardingInfo.OnBoardingStep.SIGN_UP)
+                                .let {
+                                    if (profileInfo.username != null) {
+                                        it.finishStep(OnBoardingInfo.OnBoardingStep.FILL_PROFILE)
+                                    } else {
+                                        it
+                                    }
+                                }
+
+                        is UserProfileInfo.Anonymous -> it
+                    }
+                }
+                .let {
+                    if (profileInfo.languageSetting() != null) {
+                        it.finishStep(OnBoardingInfo.OnBoardingStep.SELECT_LANGUAGES)
+                    } else {
+                        it
+                    }
+                }
+                .let {
+                    val languageSetting = profileInfo.languageSetting()
+                    if (languageSetting != null &&
+                        !contentRepository.getAllUnits(languageSetting).getOrNull().isNullOrEmpty()
+                    ) {
+                        it.finishStep(OnBoardingInfo.OnBoardingStep.DOWNLOAD_CONTENT)
+                    } else {
+                        it
+                    }
+                },
+        )
+    }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/UserProfileInfo.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/UserProfileInfo.kt
@@ -1,0 +1,24 @@
+package com.langsapp.home.onboarding
+
+import com.langsapp.model.LanguageSetting
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class UserProfileInfo {
+
+    @Serializable
+    data class SignedIn(
+        val username: String?,
+        val languageSetting: LanguageSetting?,
+    ) : UserProfileInfo()
+
+    @Serializable
+    data class Anonymous(
+        val languageSetting: LanguageSetting?,
+    ) : UserProfileInfo()
+
+    fun languageSetting() = when (this) {
+        is Anonymous -> languageSetting
+        is SignedIn -> languageSetting
+    }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/UserProfileRepository.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/home/onboarding/UserProfileRepository.kt
@@ -1,0 +1,160 @@
+package com.langsapp.home.onboarding
+
+import com.langsapp.config.KeyValueStorage
+import com.langsapp.config.Log
+import com.langsapp.data.UserProfileService
+import com.langsapp.identity.IdentityState
+import com.langsapp.identity.TokenExpiredException
+import com.langsapp.model.LanguageSetting
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class UserProfileRepository(
+    private val identityStateProvider: () -> IdentityState,
+    private val profileService: UserProfileService,
+    private val keyValueStorage: KeyValueStorage,
+) {
+    suspend fun provideProfileInfo(): Result<UserProfileInfo> =
+        // Load profile stored locally
+        keyValueStorage
+            .get(getUserStorageKey(userId = identityStateProvider().userId))
+            ?.let {
+                runCatching { Json.decodeFromString<UserProfileInfo>(it) }
+                    .onFailure { Log.e("Failed to parse ProfileInfo. Reason: $it") }
+                    .getOrNull()
+            }
+            ?.let {
+                Result.success(it)
+            }
+            ?: run {
+                when (val identityState = identityStateProvider()) {
+                    // Create new anonymous user profile
+                    is IdentityState.AnonymousUser -> {
+                        Log.d("Creating new anonymous profile for user id: ${identityState.userId}")
+                        Result.success(UserProfileInfo.Anonymous(null))
+                    }
+
+                    // Token expired, user has to sign in again
+                    is IdentityState.TokenExpired -> Result.failure(Throwable("Token expired"))
+
+                    is IdentityState.SignedIn -> {
+                        Log.d("User signed in (id: ${identityState.userId}). Downloading profile from server")
+                        runCatching { identityState.readRemoteProfile() }
+                            .mapCatching {
+                                Log.d("Downloaded profile from server: $it")
+                                it ?: createNewUserProfile(identityState)
+                            }
+                    }
+                }
+            }
+                .onSuccess {
+                    keyValueStorage.set(getUserStorageKey(identityStateProvider().userId), Json.encodeToString(it))
+                }
+
+    suspend fun updateLanguageSetting(languageSetting: LanguageSetting): Result<Unit> =
+        provideProfileInfo()
+            .mapCatching { profileInfo ->
+                when (profileInfo) {
+                    is UserProfileInfo.Anonymous -> profileInfo.copy(languageSetting = languageSetting)
+                    is UserProfileInfo.SignedIn -> {
+                        when (val identityState = identityStateProvider()) {
+                            is IdentityState.AnonymousUser -> error("Unable to update username for anonymous user.")
+                            is IdentityState.TokenExpired -> throw TokenExpiredException()
+
+                            is IdentityState.SignedIn ->
+                                profileService.upsertUserProperties(
+                                    identityState.accessToken,
+                                    listOf(UserProfileService.UserProperty.LanguageSetting(languageSetting)),
+                                )
+                                    .let {
+                                        profileInfo.copy(languageSetting = languageSetting)
+                                    }
+                        }
+                    }
+                }
+            }
+            .onSuccess {
+                keyValueStorage.set(getUserStorageKey(identityStateProvider().userId), Json.encodeToString(it))
+            }
+            .map { }
+
+    suspend fun updateUsername(username: String): Result<Unit> =
+        provideProfileInfo()
+            .mapCatching { profileInfo ->
+                when (profileInfo) {
+                    is UserProfileInfo.Anonymous -> error("Unable to update username for anonymous user.")
+                    is UserProfileInfo.SignedIn -> {
+                        when (val identityState = identityStateProvider()) {
+                            is IdentityState.SignedIn -> profileService.upsertUserProperties(
+                                identityState.accessToken,
+                                listOf(UserProfileService.UserProperty.Username(username)),
+                            )
+                                .let {
+                                    profileInfo.copy(username = username)
+                                }
+
+                            is IdentityState.AnonymousUser -> error("Unable to update username for anonymous user.")
+                            is IdentityState.TokenExpired -> throw TokenExpiredException()
+                        }
+                    }
+                }
+            }
+            .onSuccess {
+                keyValueStorage.set(
+                    getUserStorageKey(identityStateProvider().userId),
+                    Json.encodeToString(it as UserProfileInfo)
+                )
+            }
+            .map { }
+
+    private suspend fun createNewUserProfile(identityState: IdentityState.SignedIn): UserProfileInfo.SignedIn {
+        Log.d("Creating new user profile for user id: ${identityState.userId}")
+        return profileService
+            .createUserProfile(identityState.accessToken, identityState.userId)
+            .let {
+                UserProfileInfo.SignedIn(null, getLastAnonymousUserLanguageSetting())
+            }
+            .let {
+                if (it.languageSetting != null) {
+                    Log.d("Updating fresh user profile with language setting from anonymous user")
+                    updateLanguageSetting(it.languageSetting)
+                    it
+                } else {
+                    it
+                }
+            }
+    }
+
+    private fun getLastAnonymousUserLanguageSetting() =
+        keyValueStorage
+            .getAll()
+            .mapNotNull {
+                Log.d("$it")
+                if (it.key.contains(PROFILE_INFO_KEY)) {
+                    runCatching {
+                        Json.decodeFromString<UserProfileInfo>(it.value)
+                    }
+                        .getOrNull()
+                } else {
+                    null
+                }
+            }
+            .filterIsInstance<UserProfileInfo.Anonymous>()
+            .lastOrNull()
+            ?.languageSetting
+
+    private suspend fun IdentityState.SignedIn.readRemoteProfile() =
+        profileService
+            .getUserProfile(accessToken)
+            ?.let {
+                UserProfileInfo.SignedIn(
+                    username = it.username,
+                    languageSetting = it.languageSetting,
+                )
+            }
+
+    companion object {
+        private const val PROFILE_INFO_KEY = "profile-info"
+        private fun getUserStorageKey(userId: String) = "$userId-$PROFILE_INFO_KEY"
+    }
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/model/Language.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/model/Language.kt
@@ -1,0 +1,6 @@
+package com.langsapp.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Language(val code: String)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/model/LanguageSetting.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/model/LanguageSetting.kt
@@ -1,0 +1,10 @@
+package com.langsapp.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LanguageSetting(
+    val learnLanguage: Language,
+    val baseLanguage: Language,
+    val supportLanguage: Language?,
+)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/model/UserProfile.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/model/UserProfile.kt
@@ -1,0 +1,6 @@
+package com.langsapp.model
+
+data class UserProfile(
+    val username: String? = null,
+    val languageSetting: LanguageSetting? = null,
+)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/model/content/ContentUnit.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/model/content/ContentUnit.kt
@@ -1,0 +1,6 @@
+package com.langsapp.model.content
+
+data class ContentUnit(
+    val id: String,
+    val translationData: TranslationData,
+)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/model/content/TranslationData.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/model/content/TranslationData.kt
@@ -1,0 +1,10 @@
+package com.langsapp.model.content
+
+import com.langsapp.model.LanguageSetting
+
+data class TranslationData(
+    val languageSetting: LanguageSetting,
+    val baseLanguageText: String,
+    val learnLanguageText: String,
+    val supportLanguageText: String?,
+)

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsAction.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsAction.kt
@@ -1,0 +1,22 @@
+package com.langsapp.settings.language
+
+import com.langsapp.architecture.Action
+import com.langsapp.model.Language
+
+sealed class LanguageSettingsAction : Action {
+    data class AvailableLanguagesLoaded(val languages: List<Language>) : LanguageSettingsAction()
+    data object AvailableLanguagesLoadFailure : LanguageSettingsAction()
+    data class LearnLanguageChanged(val language: Language) : LanguageSettingsAction()
+    data class BaseLanguageChanged(val language: Language) : LanguageSettingsAction()
+    data class SupportLanguageChanged(val language: Language?) : LanguageSettingsAction()
+    data object ConfirmTapped : LanguageSettingsAction()
+    data object SelectionSavingSucceeded : LanguageSettingsAction()
+    data class SelectionSavingFailed(
+        val availableLanguages: List<Language>,
+        val learnLanguage: Language,
+        val baseLanguage: Language,
+        val supportLanguage: Language?,
+    ) : LanguageSettingsAction()
+    data object BackTapped : LanguageSettingsAction()
+    data object RetryTapped : LanguageSettingsAction()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsRepository.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsRepository.kt
@@ -1,0 +1,17 @@
+package com.langsapp.settings.language
+
+import com.langsapp.data.ContentService
+import com.langsapp.home.onboarding.UserProfileRepository
+import com.langsapp.model.Language
+import com.langsapp.model.LanguageSetting
+
+class LanguageSettingsRepository(
+    private val contentService: ContentService,
+    private val userProfileRepository: UserProfileRepository,
+) {
+    suspend fun fetchAvailableLanguages(): Result<List<Language>> =
+        runCatching { contentService.fetchAvailableLanguages() }
+
+    suspend fun saveSelectedLanguages(languageSetting: LanguageSetting): Result<Unit> =
+        userProfileRepository.updateLanguageSetting(languageSetting)
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsSideEffect.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsSideEffect.kt
@@ -1,0 +1,14 @@
+package com.langsapp.settings.language
+
+import com.langsapp.architecture.SideEffect
+import com.langsapp.model.Language
+
+sealed class LanguageSettingsSideEffect : SideEffect {
+    data object FetchAvailableLanguages : LanguageSettingsSideEffect()
+    data class ConfirmLanguagesSelection(
+        val availableLanguages: List<Language>,
+        val learnLanguage: Language,
+        val baseLanguage: Language,
+        val supportLanguage: Language? = null,
+    ) : LanguageSettingsSideEffect()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsState.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsState.kt
@@ -1,0 +1,16 @@
+package com.langsapp.settings.language
+
+import com.langsapp.architecture.State
+import com.langsapp.model.Language
+
+sealed class LanguageSettingsState : State {
+    data object Loading : LanguageSettingsState()
+    data object DataLoadingFailure : LanguageSettingsState()
+    data class Input(
+        val availableLanguages: List<Language>,
+        val learnLanguage: Language?,
+        val baseLanguage: Language?,
+        val supportLanguage: Language?,
+        val isInputCorrect: Boolean,
+    ) : LanguageSettingsState()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsStateManager.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/settings/language/LanguageSettingsStateManager.kt
@@ -1,0 +1,166 @@
+package com.langsapp.settings.language
+
+import com.langsapp.architecture.ActionResult
+import com.langsapp.architecture.CommonSideEffect
+import com.langsapp.architecture.StateManager
+import com.langsapp.config.Log
+import com.langsapp.model.LanguageSetting
+
+class LanguageSettingsStateManager(
+    private val languageSettingsRepository: LanguageSettingsRepository,
+) : StateManager<LanguageSettingsState, LanguageSettingsAction>(
+    initialState = LanguageSettingsState.Loading,
+    initialSideEffects = ArrayDeque(listOf(LanguageSettingsSideEffect.FetchAvailableLanguages)),
+    handleAction = { currentState, action ->
+        when (action) {
+            is LanguageSettingsAction.AvailableLanguagesLoaded -> when (currentState) {
+                LanguageSettingsState.Loading -> ActionResult(
+                    LanguageSettingsState.Input(
+                        availableLanguages = action.languages,
+                        learnLanguage = null,
+                        baseLanguage = null,
+                        supportLanguage = null,
+                        isInputCorrect = false,
+                    ),
+                )
+
+                is LanguageSettingsState.Input -> ActionResult()
+                LanguageSettingsState.DataLoadingFailure -> ActionResult()
+            }
+
+            LanguageSettingsAction.BackTapped -> ActionResult(sideEffects = listOf(CommonSideEffect.Exit))
+            is LanguageSettingsAction.BaseLanguageChanged -> when (currentState) {
+                LanguageSettingsState.Loading -> ActionResult()
+                is LanguageSettingsState.Input -> ActionResult(
+                    currentState
+                        .copy(baseLanguage = action.language)
+                        .let { it.copy(isInputCorrect = it.isValid()) },
+                )
+
+                LanguageSettingsState.DataLoadingFailure -> ActionResult()
+            }
+
+            is LanguageSettingsAction.LearnLanguageChanged -> when (currentState) {
+                LanguageSettingsState.Loading -> ActionResult()
+                is LanguageSettingsState.Input -> ActionResult(
+                    currentState
+                        .copy(learnLanguage = action.language)
+                        .let { it.copy(isInputCorrect = it.isValid()) },
+                )
+
+                LanguageSettingsState.DataLoadingFailure -> ActionResult()
+            }
+
+            is LanguageSettingsAction.SupportLanguageChanged -> when (currentState) {
+                LanguageSettingsState.Loading -> ActionResult()
+                is LanguageSettingsState.Input -> ActionResult(
+                    currentState
+                        .copy(supportLanguage = action.language)
+                        .let { it.copy(isInputCorrect = it.isValid()) },
+                )
+
+                LanguageSettingsState.DataLoadingFailure -> ActionResult()
+            }
+
+            LanguageSettingsAction.ConfirmTapped -> when (currentState) {
+                LanguageSettingsState.Loading -> ActionResult()
+                is LanguageSettingsState.Input -> {
+                    if (currentState.isValid()) {
+                        ActionResult(
+                            sideEffects =
+                            listOf(
+                                LanguageSettingsSideEffect.ConfirmLanguagesSelection(
+                                    availableLanguages = currentState.availableLanguages,
+                                    learnLanguage = currentState.learnLanguage!!,
+                                    baseLanguage = currentState.baseLanguage!!,
+                                    supportLanguage = currentState.supportLanguage,
+                                ),
+                            ),
+                        )
+                    } else {
+                        ActionResult(
+                            // TODO Replace with correctly localised text
+                            sideEffects = listOf(CommonSideEffect.ShowPopUpMessage("Invalid input. TODO Replace me")),
+                        )
+                    }
+                }
+
+                LanguageSettingsState.DataLoadingFailure -> ActionResult()
+            }
+
+            is LanguageSettingsAction.SelectionSavingFailed -> ActionResult(
+                newState = LanguageSettingsState.Input(
+                    availableLanguages = action.availableLanguages,
+                    learnLanguage = action.learnLanguage,
+                    baseLanguage = action.baseLanguage,
+                    supportLanguage = action.supportLanguage,
+                    isInputCorrect = true,
+                ),
+                sideEffects = listOf(
+                    // TODO Replace with correctly localised text
+                    CommonSideEffect.ShowPopUpMessage("Something went wrong :/ "),
+                ),
+            )
+
+            LanguageSettingsAction.SelectionSavingSucceeded -> ActionResult(
+                sideEffects = listOf(
+                    // TODO Replace with correctly localised text
+                    CommonSideEffect.ShowPopUpMessage("Languages saved successfully"),
+                    CommonSideEffect.Exit,
+                ),
+            )
+
+            LanguageSettingsAction.AvailableLanguagesLoadFailure ->
+                ActionResult()
+            LanguageSettingsAction.RetryTapped ->
+                ActionResult(
+                    newState = LanguageSettingsState.Loading,
+                    sideEffects = listOf(LanguageSettingsSideEffect.FetchAvailableLanguages),
+                )
+        }
+    },
+    handleSideEffect = { sideEffect ->
+        when (sideEffect) {
+            LanguageSettingsSideEffect.FetchAvailableLanguages ->
+                languageSettingsRepository.fetchAvailableLanguages()
+                    .fold(
+                        onSuccess = {
+                            LanguageSettingsAction.AvailableLanguagesLoaded(it)
+                        },
+                        onFailure = {
+                            LanguageSettingsAction.AvailableLanguagesLoadFailure
+                        },
+                    )
+
+            is LanguageSettingsSideEffect.ConfirmLanguagesSelection -> {
+                languageSettingsRepository.saveSelectedLanguages(
+                    LanguageSetting(
+                        learnLanguage = sideEffect.learnLanguage,
+                        baseLanguage = sideEffect.baseLanguage,
+                        supportLanguage = sideEffect.supportLanguage,
+                    ),
+                ).fold(
+                    onSuccess = { LanguageSettingsAction.SelectionSavingSucceeded },
+                    onFailure = {
+                        Log.d("Failed to update language settings.  Reason: $it")
+                        LanguageSettingsAction.SelectionSavingFailed(
+                            availableLanguages = sideEffect.availableLanguages,
+                            learnLanguage = sideEffect.learnLanguage,
+                            baseLanguage = sideEffect.baseLanguage,
+                            supportLanguage = sideEffect.supportLanguage,
+                        )
+                    },
+                )
+            }
+
+            else -> null
+        }
+    },
+)
+
+private fun LanguageSettingsState.Input.isValid() =
+    learnLanguage != baseLanguage &&
+        baseLanguage != supportLanguage &&
+        learnLanguage != supportLanguage &&
+        learnLanguage != null &&
+        baseLanguage != null

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileAction.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileAction.kt
@@ -1,0 +1,13 @@
+package com.langsapp.userprofile.upsert
+
+import com.langsapp.architecture.Action
+
+sealed class UpsertProfileAction : Action {
+    data class ConfirmTapped(
+        val newUsername: String,
+    ) : UpsertProfileAction()
+
+    data object ProfileUpdateSucceeded : UpsertProfileAction()
+    data class ProfileUpdateFailed(val reason: Throwable) : UpsertProfileAction()
+    data object BackTapped : UpsertProfileAction()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileSideEffect.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileSideEffect.kt
@@ -1,0 +1,7 @@
+package com.langsapp.userprofile.upsert
+
+import com.langsapp.architecture.SideEffect
+
+sealed class UpsertProfileSideEffect : SideEffect {
+    data class ConfirmProfileUpsert(val username: String) : UpsertProfileSideEffect()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileState.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileState.kt
@@ -1,0 +1,11 @@
+package com.langsapp.userprofile.upsert
+
+import com.langsapp.architecture.State
+import com.langsapp.model.UserProfile
+
+sealed class UpsertProfileState : State {
+    data object Loading : UpsertProfileState()
+    data class Input(
+        val currentProfile: UserProfile?,
+    ) : UpsertProfileState()
+}

--- a/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileStateManager.kt
+++ b/mobile/app/src/commonMain/kotlin/com/langsapp/userprofile/upsert/UpsertProfileStateManager.kt
@@ -1,0 +1,81 @@
+package com.langsapp.userprofile.upsert
+
+import com.langsapp.architecture.ActionResult
+import com.langsapp.architecture.CommonSideEffect
+import com.langsapp.architecture.StateManager
+import com.langsapp.config.Log
+import com.langsapp.home.onboarding.UserProfileRepository
+import com.langsapp.model.UserProfile
+
+class UpsertProfileStateManager(
+    private val currentProfile: UserProfile?,
+    private val userProfileRepository: UserProfileRepository,
+) : StateManager<UpsertProfileState, UpsertProfileAction>(
+    initialState = UpsertProfileState.Input(
+        currentProfile = currentProfile,
+    ),
+    handleAction = { currentState, action ->
+        when (action) {
+            UpsertProfileAction.BackTapped ->
+                ActionResult(sideEffects = listOf(CommonSideEffect.Exit))
+
+            is UpsertProfileAction.ConfirmTapped -> when (currentState) {
+                is UpsertProfileState.Input ->
+                    if (
+                        action.newUsername.isNotBlank() && action.newUsername != currentProfile?.username
+                    ) {
+                        ActionResult(
+                            newState = UpsertProfileState.Loading,
+                            sideEffects = listOf(
+                                UpsertProfileSideEffect.ConfirmProfileUpsert(
+                                    username = action.newUsername,
+                                ),
+                            ),
+                        )
+                    } else {
+                        ActionResult(
+                            // TODO Replace with correctly localised text
+                            sideEffects = listOf(CommonSideEffect.ShowPopUpMessage("Invalid input. TODO Replace me")),
+                        )
+                    }
+
+                else -> ActionResult()
+            }
+
+            is UpsertProfileAction.ProfileUpdateFailed -> ActionResult(
+                sideEffects = listOf(
+                    // TODO Replace with correctly localised text
+                    // TODO Handle possible "Duplicate username" or "Token expired" errors
+                    CommonSideEffect.ShowPopUpMessage("Profile update failed"),
+                ),
+            )
+
+            UpsertProfileAction.ProfileUpdateSucceeded -> ActionResult(
+                sideEffects = listOf(
+                    // TODO Replace with correctly localised text
+                    CommonSideEffect.ShowPopUpMessage("Profile saved successfully"),
+                    CommonSideEffect.Exit,
+                ),
+            )
+        }
+    },
+    handleSideEffect = {
+        when (it) {
+            is UpsertProfileSideEffect.ConfirmProfileUpsert ->
+                runCatching {
+                    userProfileRepository.updateUsername(it.username)
+                }
+                    .fold(
+                        onSuccess = {
+                            UpsertProfileAction.ProfileUpdateSucceeded
+                        },
+                        onFailure = { reason ->
+                            Log.e("Failed to update profile. Reason: $reason")
+                            UpsertProfileAction.ProfileUpdateFailed(reason = reason)
+                        },
+                    )
+
+            else -> null
+        }
+    },
+)

--- a/mobile/app/src/commonTest/kotlin/com/langsapp/InMemoryKeyValueStorage.kt
+++ b/mobile/app/src/commonTest/kotlin/com/langsapp/InMemoryKeyValueStorage.kt
@@ -5,6 +5,7 @@ import com.langsapp.config.KeyValueStorage
 class InMemoryKeyValueStorage : KeyValueStorage {
     private val map = mutableMapOf<String, String>()
     override fun get(key: String): String? = map[key]
+    override fun getAll(): Map<String, String> = map
     override fun set(key: String, value: String) = map.set(key, value)
     override fun remove(key: String) {
         map.remove(key)

--- a/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 		EB1D1D232CB708B000F77D40 /* AuthResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1D1D222CB708B000F77D40 /* AuthResult.swift */; };
 		EB1D1D252CB7CC7000F77D40 /* AppAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1D1D242CB7CC7000F77D40 /* AppAuthViewModel.swift */; };
 		EB1D1D272CB7DD7700F77D40 /* AuthResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1D1D262CB7DD7700F77D40 /* AuthResponseHandler.swift */; };
+		EB1D1D2B2CB8873900F77D40 /* LanguageSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1D1D2A2CB8873900F77D40 /* LanguageSettingsScreen.swift */; };
+		EB25844A2CD1B1F40084FBE9 /* UpsertProfileScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2584492CD1B1F40084FBE9 /* UpsertProfileScreen.swift */; };
+		EB25844C2CD1B20D0084FBE9 /* InputScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB25844B2CD1B20D0084FBE9 /* InputScreen.swift */; };
+		EB25844F2CD1B6540084FBE9 /* ManageContentScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB25844E2CD1B6540084FBE9 /* ManageContentScreen.swift */; };
+		EB2584512CD1B6D30084FBE9 /* ContentLoadFailureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2584502CD1B6D30084FBE9 /* ContentLoadFailureScreen.swift */; };
+		EB2584532CD1B91A0084FBE9 /* ContentLoadedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2584522CD1B91A0084FBE9 /* ContentLoadedScreen.swift */; };
 		EB71F7A42C635FF700B4922C /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB71F7A32C635FF700B4922C /* AppLogger.swift */; };
 		EB71F7A62C637D9000B4922C /* AppKeyValueStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB71F7A52C637D9000B4922C /* AppKeyValueStorage.swift */; };
 		EB71F7A82C63F1BA00B4922C /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB71F7A72C63F1BA00B4922C /* AppViewModel.swift */; };
@@ -49,6 +55,12 @@
 		EB1D1D222CB708B000F77D40 /* AuthResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResult.swift; sourceTree = "<group>"; };
 		EB1D1D242CB7CC7000F77D40 /* AppAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAuthViewModel.swift; sourceTree = "<group>"; };
 		EB1D1D262CB7DD7700F77D40 /* AuthResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResponseHandler.swift; sourceTree = "<group>"; };
+		EB1D1D2A2CB8873900F77D40 /* LanguageSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSettingsScreen.swift; sourceTree = "<group>"; };
+		EB2584492CD1B1F40084FBE9 /* UpsertProfileScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpsertProfileScreen.swift; sourceTree = "<group>"; };
+		EB25844B2CD1B20D0084FBE9 /* InputScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputScreen.swift; sourceTree = "<group>"; };
+		EB25844E2CD1B6540084FBE9 /* ManageContentScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageContentScreen.swift; sourceTree = "<group>"; };
+		EB2584502CD1B6D30084FBE9 /* ContentLoadFailureScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLoadFailureScreen.swift; sourceTree = "<group>"; };
+		EB2584522CD1B91A0084FBE9 /* ContentLoadedScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLoadedScreen.swift; sourceTree = "<group>"; };
 		EB71F7A32C635FF700B4922C /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
 		EB71F7A52C637D9000B4922C /* AppKeyValueStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeyValueStorage.swift; sourceTree = "<group>"; };
 		EB71F7A72C63F1BA00B4922C /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
@@ -177,9 +189,55 @@
 			path = Navigation;
 			sourceTree = "<group>";
 		};
+		EB1D1D282CB8862200F77D40 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				EB1D1D292CB8863E00F77D40 /* Language */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		EB1D1D292CB8863E00F77D40 /* Language */ = {
+			isa = PBXGroup;
+			children = (
+				EB1D1D2A2CB8873900F77D40 /* LanguageSettingsScreen.swift */,
+			);
+			path = Language;
+			sourceTree = "<group>";
+		};
+		EB2584472CD1B1CA0084FBE9 /* Userprofile */ = {
+			isa = PBXGroup;
+			children = (
+				EB2584482CD1B1DA0084FBE9 /* Upsert */,
+			);
+			path = Userprofile;
+			sourceTree = "<group>";
+		};
+		EB2584482CD1B1DA0084FBE9 /* Upsert */ = {
+			isa = PBXGroup;
+			children = (
+				EB2584492CD1B1F40084FBE9 /* UpsertProfileScreen.swift */,
+				EB25844B2CD1B20D0084FBE9 /* InputScreen.swift */,
+			);
+			path = Upsert;
+			sourceTree = "<group>";
+		};
+		EB25844D2CD1B63C0084FBE9 /* Content */ = {
+			isa = PBXGroup;
+			children = (
+				EB25844E2CD1B6540084FBE9 /* ManageContentScreen.swift */,
+				EB2584502CD1B6D30084FBE9 /* ContentLoadFailureScreen.swift */,
+				EB2584522CD1B91A0084FBE9 /* ContentLoadedScreen.swift */,
+			);
+			path = Content;
+			sourceTree = "<group>";
+		};
 		EB71F7AA2C63FA5D00B4922C /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				EB25844D2CD1B63C0084FBE9 /* Content */,
+				EB2584472CD1B1CA0084FBE9 /* Userprofile */,
+				EB1D1D282CB8862200F77D40 /* Settings */,
 				EB1D1D1B2CB6E55700F77D40 /* Identity */,
 				EB71F7AB2C63FA6D00B4922C /* Home */,
 			);
@@ -315,14 +373,20 @@
 				EB71F7AD2C63FA7E00B4922C /* WelcomeScreen.swift in Sources */,
 				EB1D1D172CB5D74900F77D40 /* ToastMessage.swift in Sources */,
 				EB71F7A82C63F1BA00B4922C /* AppViewModel.swift in Sources */,
+				EB25844F2CD1B6540084FBE9 /* ManageContentScreen.swift in Sources */,
 				EB71F7AF2C6416AF00B4922C /* HomeScreen.swift in Sources */,
 				EB1D1D272CB7DD7700F77D40 /* AuthResponseHandler.swift in Sources */,
 				EB71F7B12C6417F900B4922C /* LoadedHomeScreen.swift in Sources */,
+				EB2584532CD1B91A0084FBE9 /* ContentLoadedScreen.swift in Sources */,
 				EB1D1D142CB5D6BD00F77D40 /* ToastMessageModifier.swift in Sources */,
+				EB25844C2CD1B20D0084FBE9 /* InputScreen.swift in Sources */,
 				EB1D1D112CB5D4DE00F77D40 /* ToastMessageView.swift in Sources */,
 				EB1D1D1F2CB6F90700F77D40 /* View_NavigationExtension.swift in Sources */,
+				EB2584512CD1B6D30084FBE9 /* ContentLoadFailureScreen.swift in Sources */,
 				EB71F7A42C635FF700B4922C /* AppLogger.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				EB25844A2CD1B1F40084FBE9 /* UpsertProfileScreen.swift in Sources */,
+				EB1D1D2B2CB8873900F77D40 /* LanguageSettingsScreen.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				EB1D1D252CB7CC7000F77D40 /* AppAuthViewModel.swift in Sources */,
 				EB1D1D232CB708B000F77D40 /* AuthResult.swift in Sources */,

--- a/mobile/iosApp/iosApp/AppKeyValueStorage.swift
+++ b/mobile/iosApp/iosApp/AppKeyValueStorage.swift
@@ -17,6 +17,10 @@ class AppKeyValueStorage: KeyValueStorage {
         return localDictionary[key]
     }
     
+    func getAll() -> [String : String] {
+        return localDictionary
+    }
+    
     func remove(key: String) {
         localDictionary.removeValue(forKey: key)
     }

--- a/mobile/iosApp/iosApp/ContentView.swift
+++ b/mobile/iosApp/iosApp/ContentView.swift
@@ -14,6 +14,12 @@ struct ContentView: View {
             switch viewModel.state {
             case is HomeState:
                 HomeScreen(state: viewModel.state as! HomeState, actionSender: viewModel)
+            case is LanguageSettingsState:
+                LanguageSettingsScreen(state: viewModel.state as! LanguageSettingsState, actionSender: viewModel)
+            case is UpsertProfileState:
+                UpsertProfileScreen(state: viewModel.state as! UpsertProfileState, actionSender: viewModel)
+            case is ManageContentState:
+                ManageContentScreen(state: viewModel.state as! ManageContentState, actionSender: viewModel)
             default:
                 fatalError("Unknown state: \(viewModel.state)")
             }

--- a/mobile/iosApp/iosApp/Screens/Content/ContentLoadFailureScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Content/ContentLoadFailureScreen.swift
@@ -1,0 +1,29 @@
+//
+//  ContentLoadFailureScreen.swift
+//  iosApp
+//
+//  Created by Szymon Klimek on 30.10.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import app
+import SwiftUI
+
+struct ContentLoadFailureScreen: View {
+    let state: ManageContentState.Failure
+    let actionSender: ActionSender
+    
+    init(state: ManageContentState.Failure, actionSender: ActionSender) {
+        self.state = state
+        self.actionSender = actionSender
+    }
+    
+    var body: some View {
+        VStack {
+            Text("Manage content failure screen")
+            Button("Retry download content") {
+                actionSender.sendAction(action: ManageContentAction.DownloadUnitsTapped())
+            }
+        }
+    }
+}

--- a/mobile/iosApp/iosApp/Screens/Content/ContentLoadedScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Content/ContentLoadedScreen.swift
@@ -1,0 +1,32 @@
+//
+//  ContentLoadedScreen.swift
+//  iosApp
+//
+//  Created by Szymon Klimek on 30.10.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import app
+import SwiftUI
+
+struct ContentLoadedScreen: View {
+    let state: ManageContentState.Loaded
+    let actionSender: ActionSender
+    
+    init(state: ManageContentState.Loaded, actionSender: ActionSender) {
+        self.state = state
+        self.actionSender = actionSender
+    }
+    
+    var body: some View {
+        VStack {
+            Text("Manage content screen loaded")
+            
+            Text("Has content: \(String(describing: state.hasContent))")
+            
+            Button("Download content") {
+                actionSender.sendAction(action: ManageContentAction.DownloadUnitsTapped())
+            }
+        }
+    }
+}

--- a/mobile/iosApp/iosApp/Screens/Content/ManageContentScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Content/ManageContentScreen.swift
@@ -1,0 +1,36 @@
+//
+//  ManageContentScreen.swift
+//  iosApp
+//
+//  Created by Szymon Klimek on 30.10.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import app
+import SwiftUI
+
+struct ManageContentScreen: View {
+    let state: ManageContentState
+    let actionSender: ActionSender
+    
+    init(state: ManageContentState, actionSender: ActionSender) {
+        self.state = state
+        self.actionSender = actionSender
+    }
+    
+    var body: some View {
+        switch state {
+        case is ManageContentState.Loading:
+            VStack {
+                Text("Loading...")
+                ProgressView()
+            }
+        case is ManageContentState.Loaded:
+            ContentLoadedScreen(state: state as! ManageContentState.Loaded, actionSender: actionSender)
+        case is ManageContentState.Failure:
+            ContentLoadFailureScreen(state: state as! ManageContentState.Failure, actionSender: actionSender)
+        default:
+            fatalError("Unknown ManageContentState: \(state.description)")
+        }
+    }
+}

--- a/mobile/iosApp/iosApp/Screens/Home/LoadedHomeScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Home/LoadedHomeScreen.swift
@@ -20,9 +20,80 @@ struct LoadedHomeScreen: View {
     
     var body: some View {
         VStack {
+            let userProfileInfoResult = state.userProfileInfo
+            let onBoardingInfoResult = state.onBoardingInfo
+            
             Text("Home loaded")
-            Button("Sign up") {
-                actionSender.sendAction(action: HomeAction.SignUpTapped())
+            Text("User profile info: \(String(describing: state.userProfileInfo))")
+            
+            if userProfileInfoResult is CommonResultSuccess {
+                if (userProfileInfoResult as! CommonResultSuccess).value is UserProfileInfo.Anonymous {
+                    Button("Sign up") {
+                        actionSender.sendAction(action: HomeAction.SignUpTapped())
+                    }
+                }
+            } else {
+                Text("Failed to load user profile info")
+            }
+            
+            if onBoardingInfoResult is CommonResultSuccess {
+                let onBoardingInfo = (onBoardingInfoResult as! CommonResultSuccess).value!
+                Text("On-boarding finished: \(String(describing:onBoardingInfo.isFinished))")
+                Text("On-boarding sections:")
+                ForEach(onBoardingInfo.sections, id: \.self) { section in
+                    Text("Section root step: \(String(describing: section.rootStep))")
+                    SectionInfoView(actionSender: actionSender, stepInfo: section.rootStep)
+                    
+                    ForEach(section.childSteps, id: \.self) { stepInfo in
+                        SectionInfoView(actionSender: actionSender, stepInfo: stepInfo)
+                    }
+                }
+            }
+        }
+    }
+    
+    struct SectionInfoView: View {
+        let stepInfo: OnBoardingInfo.StepInfo
+        let actionSender: ActionSender
+        
+        
+        init(actionSender: ActionSender, stepInfo: OnBoardingInfo.StepInfo) {
+            self.stepInfo = stepInfo
+            self.actionSender = actionSender
+        }
+        
+        var body: some View {
+            Text("\(String(describing: stepInfo.step)), required: \(String(describing: stepInfo.required)), done: \(String(describing: stepInfo.done)), enabled: \(String(describing: stepInfo.enabled))")
+            
+            if !stepInfo.done {
+                let label = switch stepInfo.step {
+                case OnBoardingInfo.OnBoardingStep.selectLanguages:
+                    "Select languages"
+                case OnBoardingInfo.OnBoardingStep.signUp:
+                    "Sign up"
+                case OnBoardingInfo.OnBoardingStep.fillProfile:
+                    "Fill profile"
+                case OnBoardingInfo.OnBoardingStep.downloadContent:
+                    "Download content"
+                default:
+                    fatalError("Unknown step: \(String(describing: stepInfo.step))")
+                }
+                let action = switch stepInfo.step {
+                case OnBoardingInfo.OnBoardingStep.selectLanguages:
+                    HomeAction.SelectLanguagesTapped()
+                case OnBoardingInfo.OnBoardingStep.signUp:
+                    HomeAction.SignUpTapped()
+                case OnBoardingInfo.OnBoardingStep.fillProfile:
+                    HomeAction.UpsertProfileTapped()
+                case OnBoardingInfo.OnBoardingStep.downloadContent:
+                    HomeAction.DownloadContentTapped()
+                default:
+                    fatalError("Unknown step: \(String(describing: stepInfo.step))")
+                }
+                Button(label) {
+                    actionSender.sendAction(action: action)
+                }
+                .disabled(!stepInfo.enabled)
             }
         }
     }

--- a/mobile/iosApp/iosApp/Screens/Settings/Language/LanguageSettingsScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Settings/Language/LanguageSettingsScreen.swift
@@ -1,0 +1,88 @@
+//
+//  LanguageSettingsScreen.swift
+//  iosApp
+//
+//  Created by Szymon Klimek on 11.10.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import app
+import SwiftUI
+
+struct LanguageSettingsScreen: View {
+    let state: LanguageSettingsState
+    let actionSender: ActionSender
+    
+    init(state: LanguageSettingsState, actionSender: ActionSender) {
+        self.state = state
+        self.actionSender = actionSender
+    }
+    
+    var body: some View {
+        switch state {
+        case is LanguageSettingsState.Loading:
+            ProgressView()
+        case is LanguageSettingsState.Input:
+            VStack {
+                let availableLanguages = (state as! LanguageSettingsState.Input).availableLanguages
+                Text("Language settings input")
+                Button("Back") {
+                    actionSender.sendAction(action: LanguageSettingsAction.BackTapped())
+                }
+                Spacer()
+                Text("Learn language")
+                LanguageSettingsSelector(languages: availableLanguages) { language in
+                    actionSender.sendAction(action: LanguageSettingsAction.LearnLanguageChanged(language: language))
+                }
+                Text("Base language")
+                LanguageSettingsSelector(languages: availableLanguages) { language in
+                    actionSender.sendAction(action: LanguageSettingsAction.BaseLanguageChanged(language: language))
+                }
+                Text("Support language")
+                LanguageSettingsSelector(languages: availableLanguages) { language in
+                    actionSender.sendAction(action: LanguageSettingsAction.SupportLanguageChanged(language: language))
+                }
+                Spacer()
+                Button("Confirm") {
+                    actionSender.sendAction(action: LanguageSettingsAction.ConfirmTapped())
+                }
+            }
+            
+        case is LanguageSettingsState.DataLoadingFailure:
+            VStack {
+                Text("Language settings data loading failure")
+                Button("Back") {
+                    actionSender.sendAction(action: LanguageSettingsAction.BackTapped())
+                }
+            }
+        default:
+            fatalError("Unknown language settings state: \(state.description)")
+        }
+    }
+}
+
+struct LanguageSettingsSelector: View {
+    @SwiftUI.State private var selectedLanguage: String
+    private let languages: [Language]
+    private let onLanguageChanged : (Language) -> ()
+    
+    init(languages: [Language], onLanguageChanged: @escaping (Language) -> ()) {
+        selectedLanguage = languages.first!.code
+        self.languages = languages
+        self.onLanguageChanged = onLanguageChanged
+    }
+    var body: some View {
+        Picker("languages", selection: $selectedLanguage) {
+            ForEach(languages, id: \.self) {
+                Text($0.code).tag($0.code)
+            }
+        }
+        .pickerStyle(.wheel)
+        .onAppear(perform: {
+            onLanguageChanged(Language(code:selectedLanguage))
+        })
+        .onChange(of: selectedLanguage, perform: { languageCode in
+            onLanguageChanged(Language(code:selectedLanguage))
+        })
+    }
+}

--- a/mobile/iosApp/iosApp/Screens/Userprofile/Upsert/InputScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Userprofile/Upsert/InputScreen.swift
@@ -1,0 +1,35 @@
+//
+//  InputScreen.swift
+//  iosApp
+//
+//  Created by Szymon Klimek on 30.10.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import app
+import SwiftUI
+
+struct InputScreen: View {
+    let state: UpsertProfileState.Input
+    let actionSender: ActionSender
+    
+    @SwiftUI.State private var username: String = ""
+    
+    init(state: UpsertProfileState.Input, actionSender: ActionSender) {
+        self.state = state
+        self.actionSender = actionSender
+    }
+    
+    var body: some View {
+        VStack {
+            Text("Upsert profile")
+            Text("Current profile: \(String(describing: state.currentProfile))")
+            Form {
+                TextField("Username", text: $username)
+            }
+            Button("Confirm") {
+                actionSender.sendAction(action: UpsertProfileAction.ConfirmTapped(newUsername: username))
+            }
+        }
+    }
+}

--- a/mobile/iosApp/iosApp/Screens/Userprofile/Upsert/UpsertProfileScreen.swift
+++ b/mobile/iosApp/iosApp/Screens/Userprofile/Upsert/UpsertProfileScreen.swift
@@ -1,0 +1,34 @@
+//
+//  UpsertProfileScreen.swift
+//  iosApp
+//
+//  Created by Szymon Klimek on 30.10.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import app
+import SwiftUI
+
+struct UpsertProfileScreen: View {
+    let state: UpsertProfileState
+    let actionSender: ActionSender
+    
+    init(state: UpsertProfileState, actionSender: ActionSender) {
+        self.state = state
+        self.actionSender = actionSender
+    }
+    
+    var body: some View {
+        switch state {
+        case is UpsertProfileState.Input:
+            InputScreen(state: state as! UpsertProfileState.Input, actionSender: actionSender)
+        case is UpsertProfileState.Loading:
+            VStack {
+                Text("Loading...")
+                ProgressView()
+            }
+        default:
+            fatalError("Unknown upsert profile state: \(state.description)")
+        }
+    }
+}


### PR DESCRIPTION
This commit brings foundation of user on-boarding i.e.: whole business logic of getting user ready to use the app.

The on-boarding as of now consists of multiple steps:
1. Language selection (required): learn, base (the one expected to be known by user) and support language (extra language to allowing user to get learning units translated into this as well)
2. Content download (required): process of getting the content for specific language selection, in the future tailored to the user based on other conditions
3. Sign up (optional) and profile creation: to make use of social part of the app like sharing progress etc., this allows to create account and provide "user name" for now (to be expanded in the future)

Apps UI is just placeholder to be reworked, allowing to play with business logic.