### PR TITLE
Add first API server side integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,10 +64,22 @@ spotless {
         trimTrailingWhitespace()
         ktlint()
     }
+    gherkin {
+        target(
+            fileTree(".") {
+                include("**/*.feature")
+            },
+        )
+        gherkinUtils()
+    }
+}
+
+tasks.named("spotlessKotlinGradle") {
+    dependsOn("spotlessGherkin")
 }
 
 tasks.named("spotlessKotlin") {
-    dependsOn("spotlessKotlinGradle")
+    dependsOn("spotlessKotlinGradle", "spotlessGherkin")
 }
 
 // endregion

--- a/service/gradle/libs.versions.toml
+++ b/service/gradle/libs.versions.toml
@@ -4,8 +4,11 @@ kotlin-coroutines = "1.6.1"
 ecwid-consul-api = "1.4.5"
 arrow = "1.2.0-RC"
 auth0-java-jwt = "4.4.0"
-junit-jupiter = "5.0.3"
+junit-jupiter = "5.10.3"
 mockwebserver = "4.12.0"
+junit-platform-suite = "1.10.2"
+cucumber = "7.18.1"
+testcontainers = "1.20.3"
 
 [libraries]
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
@@ -27,7 +30,17 @@ arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 auth0-java-jwt = { module = "com.auth0:java-jwt", version.ref = "auth0-java-jwt" }
 
 # Test libraries
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter"  }
+junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "junit-platform-suite" }
+
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver"}
+
+cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }
+cucumber-junit-platform-engine = { module = "io.cucumber:cucumber-junit-platform-engine", version.ref = "cucumber" }
+cucumber-spring = { module = "io.cucumber:cucumber-spring", version.ref = "cucumber" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }

--- a/service/langsapp/build.gradle.kts
+++ b/service/langsapp/build.gradle.kts
@@ -18,6 +18,13 @@ dependencies {
     implementation(project(":user-commands"))
     implementation(project(":user-follow-commands"))
     implementation(project(":user-profile-query"))
+
+    testImplementation(libs.cucumber.java)
+    testImplementation(libs.cucumber.junit.platform.engine)
+    testImplementation(libs.cucumber.spring)
+    testImplementation(libs.junit.platform.suite)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.testcontainers.junit.jupiter)
 }
 
 tasks.withType<KotlinCompile> {

--- a/service/langsapp/src/test/kotlin/com/klimek/langsapp/service/CucumberSteps.kt
+++ b/service/langsapp/src/test/kotlin/com/klimek/langsapp/service/CucumberSteps.kt
@@ -1,0 +1,77 @@
+package com.klimek.langsapp.service
+
+import io.cucumber.java.en.Given
+import io.cucumber.java.en.Then
+import io.cucumber.java.en.When
+import io.cucumber.spring.CucumberContextConfiguration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.FluxExchangeResult
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.returnResult
+import org.springframework.web.reactive.function.BodyInserters
+
+@CucumberContextConfiguration
+@SpringBootTest
+@AutoConfigureMockMvc
+class CucumberSteps {
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    private var authenticatedUserId: String? = null
+    private var requestMethod: HttpMethod? = null
+    private var requestPath: String? = null
+    private var requestBody: String? = null
+    private var actionResult: FluxExchangeResult<String>? = null
+
+    @Given("authenticated user with id {string}")
+    fun authenticatedUserWithId(id: String) {
+        authenticatedUserId = id
+    }
+
+    @Given("request method {string}")
+    fun requestMethod(method: String) {
+        requestMethod = HttpMethod.valueOf(method)
+    }
+
+    @Given("request path {string}")
+    fun requestPath(path: String) {
+        requestPath = path
+    }
+
+    @Given("request body")
+    fun requestBody(body: String) {
+        requestBody = body
+    }
+
+    @When("request is sent")
+    fun `request is sent`() {
+        println("Sending request $requestMethod, $requestPath, $requestBody")
+        actionResult = webTestClient
+            .method(requestMethod!!)
+            .uri(requestPath!!)
+            .contentType(MediaType.APPLICATION_JSON)
+            .apply {
+                if (authenticatedUserId != null) {
+                    header("Authorization", authenticatedUserId)
+                }
+            }
+            .body(BodyInserters.fromValue(requestBody!!))
+            .exchange()
+            .returnResult<String>()
+    }
+
+    @Then("response code is {string}")
+    fun responseCodeIs(status: String) {
+        assertEquals(status, actionResult!!.status.value().toString())
+    }
+
+    @Then("response body is")
+    fun responseBodyIs(body: String) {
+        assertEquals(body, String(actionResult!!.responseBodyContent!!))
+    }
+}

--- a/service/langsapp/src/test/kotlin/com/klimek/langsapp/service/CucumberTestRunner.kt
+++ b/service/langsapp/src/test/kotlin/com/klimek/langsapp/service/CucumberTestRunner.kt
@@ -1,0 +1,8 @@
+package com.klimek.langsapp.service
+
+import org.junit.platform.suite.api.SelectClasspathResource
+import org.junit.platform.suite.api.Suite
+
+@Suite
+@SelectClasspathResource("integration-tests")
+class CucumberTestRunner

--- a/service/langsapp/src/test/resources/integration-tests/creating_updating_users.feature
+++ b/service/langsapp/src/test/resources/integration-tests/creating_updating_users.feature
@@ -1,0 +1,65 @@
+Feature: Creating and updating users test
+
+  Scenario: 1. Fresh user can be created, updated and returned correctly
+    # Creating user
+    Given authenticated user with id "user-id-coming-from-oauth-identity-provider"
+    * request method "POST"
+    * request path "/user"
+    * request body
+      """
+      {
+        "id": "unique_user_id"
+      }
+      """
+    When request is sent
+    Then response code is "200"
+    # Getting profile of the user
+    * request method "GET"
+    * request path "/profile"
+    When request is sent
+    Then response code is "200"
+    * response body is
+      """
+      {"user_profile":{"id":"user-id-coming-from-oauth-identity-provider","following_count":0,"followers_count":0,"name":null,"avatar_url":null,"language_settings":null}}
+      """
+    # Updating user data
+    * request method "PATCH"
+    * request path "/user"
+    * request body
+      """
+      {
+        "username": "Unique username"
+      }
+      """
+    When request is sent
+    Then response code is "200"
+    # Updating user data
+    * request method "PATCH"
+    * request path "/user"
+    * request body
+      """
+      {
+        "language_settings": {
+          "learn_language": {
+            "code": "en"
+          },
+          "base_language": {
+            "code": "pl"
+          },
+          "support_language": {
+            "code": "de"
+          }
+        }
+      }
+      """
+    When request is sent
+    Then response code is "200"
+    # Getting profile of the user again
+    * request method "GET"
+    * request path "/profile"
+    When request is sent
+    Then response code is "200"
+    * response body is
+      """
+      {"user_profile":{"id":"user-id-coming-from-oauth-identity-provider","following_count":0,"followers_count":0,"name":"Unique username","avatar_url":null,"language_settings":{"learn_language":{"code":"en"},"base_language":{"code":"pl"},"support_language":{"code":"de"}}}}
+      """


### PR DESCRIPTION
* As a good start this adds first test suite for creating, updating and retrieving user on the server side
* The solution is based on Cucumber with the tests written in more/less generic way i.e.: staying in technical terms of executing http requests (instead of explaining behaviours)
* This makes it easily reusable to build many other scenarios with limited necessary Cucumber test steps to implement